### PR TITLE
닉네임 중복 검사 완성, 프로필 이미지 수정

### DIFF
--- a/final-project/src/main/java/com/kh/finale/controller/home/HomeController.java
+++ b/final-project/src/main/java/com/kh/finale/controller/home/HomeController.java
@@ -33,7 +33,7 @@ public class HomeController {
 	
 	// 마이페이지 조회
 	@Autowired
-	private FollowDao followDao;
+	private FollowDao followDao; 
 	@RequestMapping("/member/{memberNick}")
 	public String myPage(@PathVariable String memberNick
 			,Model model,HttpSession session) {

--- a/final-project/src/main/java/com/kh/finale/controller/home/HomeController.java
+++ b/final-project/src/main/java/com/kh/finale/controller/home/HomeController.java
@@ -33,7 +33,7 @@ public class HomeController {
 	
 	// 마이페이지 조회
 	@Autowired
-	private FollowDao followDao; 
+	private FollowDao followDao;
 	@RequestMapping("/member/{memberNick}")
 	public String myPage(@PathVariable String memberNick
 			,Model model,HttpSession session) {

--- a/final-project/src/main/java/com/kh/finale/controller/member/MemberController.java
+++ b/final-project/src/main/java/com/kh/finale/controller/member/MemberController.java
@@ -18,6 +18,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -75,15 +76,54 @@ public class MemberController {
 		return idResult;
 	}
 	
-	// 회원 가입 닉네임 중복체크
-	@PostMapping("/nickCheck")
-	@ResponseBody
-	public boolean nickCheck(@ModelAttribute MemberVo memberVo) {
-		System.out.println("닉네임 중복값 체크 : " + memberVo);
-		boolean Nickresult = memberFindService.nickCheck(memberVo) > 0;
-		System.out.println("닉네임 체크값 반환 : " + Nickresult);
-		return Nickresult;
-		}
+	// 닉네임 중복체크
+//	@PostMapping("/nickCheck")
+//	@ResponseBody
+//	public boolean nickCheck(@ModelAttribute MemberVo memberVo, HttpSession httpSession) {
+//		MemberDto memberDto;
+//		boolean result = false;
+//		if (httpSession.getAttribute("memberNo") != null) {
+//			memberDto = memberDao.findInfo((int) httpSession.getAttribute("memberNo"));
+//		System.out.println("닉네임 중복값 체크 : " + memberVo);
+//		MemberVo Nickresult = memberFindService.nickCheck(memberVo);
+//		System.out.println("닉네임 체크값 반환 : " + Nickresult);
+//		System.out.println("닉첵 : "+ Nickresult.getMemberNick());
+//		System.out.println("디첵 : "+ memberDto.getMemberNick());
+//			if(Nickresult.getMemberNick() == memberDto.getMemberNick() || Nickresult.getMemberNick() == null) {
+//				result = false;
+//			}
+//			else {
+//				result = true;
+//			}
+//		}
+//		System.out.println(result);
+//		return result;
+//		}
+	
+		// 닉네임 중복체크
+		@PostMapping("/nickCheck")
+		@ResponseBody
+		public boolean nickCheck(@ModelAttribute MemberVo memberVo, HttpSession httpSession) {
+			System.out.println("닉네임 중복값 체크 : " + memberVo);
+			MemberVo Nickresult = memberFindService.nickCheck(memberVo);
+			System.out.println("닉네임 체크값 반환 : " + Nickresult);
+			httpSession.getAttribute("memberNo");
+				MemberDto memberDto = memberDao.findInfo((int) httpSession.getAttribute("memberNo"));
+			boolean result = false;
+			if(ObjectUtils.isEmpty(Nickresult)) {
+				result = false;
+			}
+			else {
+				if(Nickresult.getMemberNick().equals(memberDto.getMemberNick())) {
+					result = false;
+				}
+				else {
+					result = true;
+				}
+			}
+			System.out.println(result);
+			return result;
+			}
 	
 	// 로그인 페이지
 	@GetMapping("/login")
@@ -244,7 +284,7 @@ public class MemberController {
 	@Autowired
 	MemberEditService memberEditService;
 	
-	// 마이페이지 수정 기능
+	// 프로필 편집
 	@PostMapping("/editProfile")
 	public String editProfile(@ModelAttribute MemberVo memberVo, HttpSession httpSession) {
 		System.out.println("수신값 검사 : " + memberVo);

--- a/final-project/src/main/java/com/kh/finale/controller/member/MemberController.java
+++ b/final-project/src/main/java/com/kh/finale/controller/member/MemberController.java
@@ -41,31 +41,31 @@ import com.kh.finale.vo.member.MemberVo;
 @Controller
 @RequestMapping("/member")
 public class MemberController {
-	
+
 	@Autowired
 	MemberDao memberDao;
-	
+
 	// 회원 가입 페이지
 	@GetMapping("/join")
 	public String join() {
 		return "member/join";
 	}
-	
+
 	@Autowired
 	private MemberJoinService memberJoinService;
-	
+
 	@PostMapping("/join")
 	public String join(@ModelAttribute MemberVo memberVo) throws IllegalStateException, IOException {
 		System.out.println("수신값 확인 : " + memberVo);
-		memberJoinService.memberjoin(memberVo);		
-		return "redirect:join_success"; 
+		memberJoinService.memberjoin(memberVo);
+		return "redirect:join_success";
 	}
-	
+
 	@GetMapping("/join_success")
 	public String registSuccess() {
 		return "member/joinSuccess";
 	}
-	
+
 	// 회원 가입 아이디 중복체크
 	@PostMapping("/idCheck")
 	@ResponseBody
@@ -76,76 +76,57 @@ public class MemberController {
 		return idResult;
 	}
 	
-	// 닉네임 중복체크
-//	@PostMapping("/nickCheck")
-//	@ResponseBody
-//	public boolean nickCheck(@ModelAttribute MemberVo memberVo, HttpSession httpSession) {
-//		MemberDto memberDto;
-//		boolean result = false;
-//		if (httpSession.getAttribute("memberNo") != null) {
-//			memberDto = memberDao.findInfo((int) httpSession.getAttribute("memberNo"));
-//		System.out.println("닉네임 중복값 체크 : " + memberVo);
-//		MemberVo Nickresult = memberFindService.nickCheck(memberVo);
-//		System.out.println("닉네임 체크값 반환 : " + Nickresult);
-//		System.out.println("닉첵 : "+ Nickresult.getMemberNick());
-//		System.out.println("디첵 : "+ memberDto.getMemberNick());
-//			if(Nickresult.getMemberNick() == memberDto.getMemberNick() || Nickresult.getMemberNick() == null) {
-//				result = false;
-//			}
-//			else {
-//				result = true;
-//			}
-//		}
-//		System.out.println(result);
-//		return result;
-//		}
-	
-		// 닉네임 중복체크
-		@PostMapping("/nickCheck")
-		@ResponseBody
-		public boolean nickCheck(@ModelAttribute MemberVo memberVo, HttpSession httpSession) {
-			System.out.println("닉네임 중복값 체크 : " + memberVo);
-			MemberVo Nickresult = memberFindService.nickCheck(memberVo);
-			System.out.println("닉네임 체크값 반환 : " + Nickresult);
-			httpSession.getAttribute("memberNo");
-				MemberDto memberDto = memberDao.findInfo((int) httpSession.getAttribute("memberNo"));
-			boolean result = false;
-			if(ObjectUtils.isEmpty(Nickresult)) {
+	// 회원가입 닉네임 중복체크
+	@PostMapping("/jNickCheck")
+	@ResponseBody
+	public boolean jNickCheck(@ModelAttribute MemberVo memberVo) {
+		System.out.println("닉네임 중복값 체크 : " + memberVo);
+		boolean Nickresult = memberFindService.jNickCheck(memberVo) > 0;
+		System.out.println("닉네임 체크값 반환 : " + Nickresult);
+		return Nickresult;
+	}
+
+	// 프로필 편집 닉네임 중복체크
+	@PostMapping("/pNickCheck")
+	@ResponseBody
+	public boolean pNickCheck(@ModelAttribute MemberVo memberVo, HttpSession httpSession) {
+		System.out.println("닉네임 중복값 체크 : " + memberVo);
+		MemberVo Nickresult = memberFindService.pNickCheck(memberVo);
+		System.out.println("닉네임 체크값 반환 : " + Nickresult);
+		MemberDto memberDto = memberDao.findInfo((int) httpSession.getAttribute("memberNo"));
+		boolean result = false;
+		if (ObjectUtils.isEmpty(Nickresult)) {
+			result = false;
+		} else {
+			if (Nickresult.getMemberNick().equals(memberDto.getMemberNick())) {
 				result = false;
+			} else {
+				result = true;
 			}
-			else {
-				if(Nickresult.getMemberNick().equals(memberDto.getMemberNick())) {
-					result = false;
-				}
-				else {
-					result = true;
-				}
-			}
-			System.out.println(result);
-			return result;
-			}
-	
+		}
+		System.out.println(result);
+		return result;
+	}
+
 	// 로그인 페이지
 	@GetMapping("/login")
 	public String login() {
 		return "member/login";
 	}
-	
+
 	// 로그인 처리
 	@PostMapping("/login")
-	public String login(@ModelAttribute MemberDto memberDto,
-			HttpSession httpSession) {
+	public String login(@ModelAttribute MemberDto memberDto, HttpSession httpSession) {
 		MemberDto check = memberDao.login(memberDto);
-		if(check != null) {
+		if (check != null) {
 			httpSession.setAttribute("memberNo", check.getMemberNo());
 			httpSession.setAttribute("memberId", check.getMemberId());
 			return "redirect:/";
-		}
-		else {
+		} else {
 			return "redirect:login?error";
 		}
 	}
-	
+
 	// 로그아웃 처리
 	@GetMapping("/logout")
 	public String logout(HttpSession httpSession) {
@@ -153,65 +134,64 @@ public class MemberController {
 		httpSession.removeAttribute("memberId");
 		return "redirect:/";
 	}
-	
+
 	// 아이디 찾기 페이지
 	@GetMapping("/findId")
 	public String findId() {
-		return "member/findId"; 
+		return "member/findId";
 	}
-	
+
 	@Autowired
 	MemberFindService memberFindService;
-	
+
 	// 아이디 찾기 처리
-		@PostMapping("/findId")
-		public ModelAndView findId(@ModelAttribute MemberDto memberDto) {
-			ModelAndView mav = new ModelAndView();
-			Object modelList = memberFindService.findId(memberDto);
-			System.out.println(modelList);
-			if(modelList == null) {
-				mav.setViewName("member/findId");
-				mav.addObject("memberDto", memberDto);
-				return mav;
-			}
-			else {
-				mav.setViewName("member/findId");
-				mav.addObject("memberDto", modelList);
-				return mav;
-			}
+	@PostMapping("/findId")
+	public ModelAndView findId(@ModelAttribute MemberDto memberDto) {
+		ModelAndView mav = new ModelAndView();
+		Object modelList = memberFindService.findId(memberDto);
+		System.out.println(modelList);
+		if (modelList == null) {
+			mav.setViewName("member/findId");
+			mav.addObject("memberDto", memberDto);
+			return mav;
+		} else {
+			mav.setViewName("member/findId");
+			mav.addObject("memberDto", modelList);
+			return mav;
 		}
-	
+	}
 
 	// 비밀번호 찾기 페이지
 	@GetMapping("/findPw")
 	public String findPw() {
 		return "member/findPw";
 	}
-	
+
 	@Autowired
 	MemberAuthService memberAuthService;
-	
+
 	@Autowired
 	MemberAuthDto memberAuthDto;
-	
+
 	// 비밀번호 찾기 (인증번호 발송)
 	@PostMapping("sendAuthEmail")
 	@ResponseBody
-	public Map<String, Object> findPw(@ModelAttribute MemberVo memberVo) throws MessagingException, UnsupportedEncodingException {
-		Map<String,Object> sendAuthEmail = new HashMap<>();
+	public Map<String, Object> findPw(@ModelAttribute MemberVo memberVo)
+			throws MessagingException, UnsupportedEncodingException {
+		Map<String, Object> sendAuthEmail = new HashMap<>();
 		System.out.println("폼 수신값 확인 : " + memberVo);
 		MemberVo searchResult = memberFindService.findPw(memberVo);
 		System.out.println("FindId 수신값 확인 : " + searchResult);
-		
-		MemberAuthDto authResult = memberAuthService.pwSendEmail(searchResult); 
+
+		MemberAuthDto authResult = memberAuthService.pwSendEmail(searchResult);
 		System.out.println("authResult 수신값 확인 : " + authResult);
 		memberAuthService.authInsert(authResult);
 		Map<String, Object> memberAuthDto = memberAuthService.resultAuth(authResult);
 		System.out.println("마지막 값 확인 : " + memberAuthDto);
 		return memberAuthDto;
-		
+
 	}
-	
+
 	// 비밀번호 찾기 (반환값 전송)
 	@PostMapping("checkAuthEmail")
 	@ResponseBody
@@ -220,73 +200,72 @@ public class MemberController {
 		System.out.println("폼 수신값 : " + memberAuthDto);
 		MemberAuthDto checkData = memberFindService.checkAuthEmail(memberAuthDto);
 		System.out.println("인증 결과 리턴 : " + checkData);
-		if(checkData == null) {
+		if (checkData == null) {
 			mav.setView(new MappingJackson2JsonView());
 			mav.addObject("memberId", memberAuthDto.getMemberId());
 			mav.setViewName("null");
 			return mav;
-		}
-		else {
+		} else {
 			mav.setViewName("member/changePw");
-			mav.addObject("checkData",checkData);
+			mav.addObject("checkData", checkData);
 			System.out.println("Mav값 확인 : " + mav);
-			return mav; 
+			return mav;
 		}
 	}
-	
+
 	// 비밀번호 찾기 (변경 페이지 이동)
 	@GetMapping("/changePw")
-	public String changePw(@ModelAttribute MemberAuthDto memberAuthDto, Model model){
+	public String changePw(@ModelAttribute MemberAuthDto memberAuthDto, Model model) {
 		System.out.println("인증페이지 수신값 : " + memberAuthDto);
 		MemberAuthDto selectMember = memberAuthService.selectId(memberAuthDto);
 		System.out.println("db 수신 값 : " + selectMember);
-			model.addAttribute("memberId", selectMember.getMemberId());
-			return "member/changePw";
+		model.addAttribute("memberId", selectMember.getMemberId());
+		return "member/changePw";
 	}
+
 	// 비밀번호 찾기 (변경 후 메인페이지 리다이렉트)
 	@PostMapping("/edit")
-	public String edit(@ModelAttribute MemberDto memberDto){
+	public String edit(@ModelAttribute MemberDto memberDto) {
 		System.out.println("리다이렉트 전 검사 : " + memberDto);
 		memberAuthService.updatePw(memberDto);
 		return "redirect:/";
 	}
-	
+
 	// 마이페이지 이미지 출력
-	
+
 	@Autowired
 	MemberProfileDao memberProfileDao;
-	
+
 	@Autowired
 	HttpSession httpSession;
-	
+
 	@GetMapping("/profileImage")
-	public ResponseEntity<ByteArrayResource> image() throws IOException{
+	public ResponseEntity<ByteArrayResource> image() throws IOException {
 		String memberId = (String) httpSession.getAttribute("memberId");
 		System.out.println("아이디 값 :" + memberId);
 		MemberProfileDto memberProfileDto = memberProfileDao.find(memberId);
-		if(memberProfileDto == null) {
+		if (memberProfileDto == null) {
 			return ResponseEntity.notFound().build();
 		}
-		
+
 		File target = new File("D:/upload/kh5/member", memberProfileDto.getProfileSaveName());
 		byte[] data = FileUtils.readFileToByteArray(target);
 		ByteArrayResource resource = new ByteArrayResource(data);
-		
-		return ResponseEntity.ok()
-					.contentLength(memberProfileDto.getProfileSize())
-					.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE)
-					.header(HttpHeaders.CONTENT_ENCODING, "UTF-8")
-					.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\""+URLEncoder.encode(memberProfileDto.getProfileOriginName(), "UTF-8")+"\"")
+
+		return ResponseEntity.ok().contentLength(memberProfileDto.getProfileSize())
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE)
+				.header(HttpHeaders.CONTENT_ENCODING, "UTF-8")
+				.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\""
+						+ URLEncoder.encode(memberProfileDto.getProfileOriginName(), "UTF-8") + "\"")
 				.body(resource);
 	}
-	
-	
+
 	@Autowired
 	MemberEditService memberEditService;
-	
+
 	// 프로필 편집
 	@PostMapping("/editProfile")
-	public String editProfile(@ModelAttribute MemberVo memberVo, HttpSession httpSession) {
+	public String editProfile(@ModelAttribute MemberVo memberVo, HttpSession httpSession) throws IllegalStateException, IOException {
 		System.out.println("수신값 검사 : " + memberVo);
 		memberVo.setMemberNo((int) httpSession.getAttribute("memberNo"));
 		memberVo.setMemberId((String) httpSession.getAttribute("memberId"));
@@ -295,7 +274,7 @@ public class MemberController {
 
 		return "redirect:/";
 	}
-	
+
 	// 회원 탈퇴
 	@GetMapping("/exit")
 	public String exit(HttpSession httpSession, MemberVo memberVo) {
@@ -306,5 +285,5 @@ public class MemberController {
 		httpSession.removeAttribute("memberId");
 		return "member/exit";
 	}
-	
+
 }

--- a/final-project/src/main/java/com/kh/finale/repository/member/MemberDao.java
+++ b/final-project/src/main/java/com/kh/finale/repository/member/MemberDao.java
@@ -20,6 +20,6 @@ public interface MemberDao {
 	void updatePw(MemberDto memberDto);
 	void editProfile(MemberVo memberVo);
 	int idCheck(MemberVo memberVo);
-	int nickCheck(MemberVo memberVo);
+	MemberVo nickCheck(MemberVo memberVo);
 	void exit(MemberVo memberVo);
 }

--- a/final-project/src/main/java/com/kh/finale/repository/member/MemberDao.java
+++ b/final-project/src/main/java/com/kh/finale/repository/member/MemberDao.java
@@ -20,6 +20,7 @@ public interface MemberDao {
 	void updatePw(MemberDto memberDto);
 	void editProfile(MemberVo memberVo);
 	int idCheck(MemberVo memberVo);
-	MemberVo nickCheck(MemberVo memberVo);
+	MemberVo pNickCheck(MemberVo memberVo);
+	int jNickCheck(MemberVo memberVo);
 	void exit(MemberVo memberVo);
 }

--- a/final-project/src/main/java/com/kh/finale/repository/member/MemberDaoImpl.java
+++ b/final-project/src/main/java/com/kh/finale/repository/member/MemberDaoImpl.java
@@ -78,15 +78,22 @@ public class MemberDaoImpl implements MemberDao{
 	public int idCheck(MemberVo memberVo) {
 		return sqlSession.selectOne("member.idCheck", memberVo);
 	}
-
+	
+	// 프로필 편집 닉네임 중복값 검사
 	@Override
-	public MemberVo nickCheck(MemberVo memberVo) {
-		return sqlSession.selectOne("member.nickCheck", memberVo);
+	public MemberVo pNickCheck(MemberVo memberVo) {
+		return sqlSession.selectOne("member.pNickCheck", memberVo);
 	}
 
 	@Override
 	public void exit(MemberVo memberVo) {
 		sqlSession.delete("member.exit", memberVo);
+	}
+	
+	// 회원 가입 닉네임 중복값 검사
+	@Override
+	public int jNickCheck(MemberVo memberVo) {
+		return sqlSession.selectOne("member.jNickCheck", memberVo);
 	}
 
 }

--- a/final-project/src/main/java/com/kh/finale/repository/member/MemberDaoImpl.java
+++ b/final-project/src/main/java/com/kh/finale/repository/member/MemberDaoImpl.java
@@ -80,7 +80,7 @@ public class MemberDaoImpl implements MemberDao{
 	}
 
 	@Override
-	public int nickCheck(MemberVo memberVo) {
+	public MemberVo nickCheck(MemberVo memberVo) {
 		return sqlSession.selectOne("member.nickCheck", memberVo);
 	}
 

--- a/final-project/src/main/java/com/kh/finale/service/member/MemberEditService.java
+++ b/final-project/src/main/java/com/kh/finale/service/member/MemberEditService.java
@@ -1,9 +1,11 @@
 package com.kh.finale.service.member;
 
+import java.io.IOException;
+
 import com.kh.finale.vo.member.MemberVo;
 
 public interface MemberEditService {
-	void editProfile(MemberVo memberVo);
+	void editProfile(MemberVo memberVo) throws IllegalStateException, IOException;
 	void exit(MemberVo memberVo);
 	void exitProfile(MemberVo memberVo);
 }

--- a/final-project/src/main/java/com/kh/finale/service/member/MemberEditServiceImpl.java
+++ b/final-project/src/main/java/com/kh/finale/service/member/MemberEditServiceImpl.java
@@ -1,6 +1,7 @@
 package com.kh.finale.service.member;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -20,10 +21,11 @@ public class MemberEditServiceImpl implements MemberEditService{
 	MemberProfileDao memberProfileDao;
 	
 	@Override
-	public void editProfile(MemberVo memberVo) {
+	public void editProfile(MemberVo memberVo) throws IllegalStateException, IOException {
 		// 회원 이미지 수정
-		try {
-			
+		
+		
+		if(!memberVo.getMemberProfile().isEmpty()) {
 		// 프로필 이미지 경로
 		File dir = new File("D:/upload/kh5/member");
 		dir.mkdir();
@@ -42,9 +44,6 @@ public class MemberEditServiceImpl implements MemberEditService{
 													.build();
 		memberProfileDao.update(memberProfileDto);
 		System.out.println("수정 DB 값 확인" + memberProfileDto);
-		}
-		catch(Exception e){
-			e.printStackTrace();
 		}
 		
 		// 이미지를 제외한 회원정보 수정

--- a/final-project/src/main/java/com/kh/finale/service/member/MemberFindService.java
+++ b/final-project/src/main/java/com/kh/finale/service/member/MemberFindService.java
@@ -9,5 +9,6 @@ public interface MemberFindService {
 	MemberVo findPw(MemberVo memberVo);
 	MemberAuthDto checkAuthEmail(MemberAuthDto memberAuthDto);
 	int idCheck(MemberVo memberVo);
-	MemberVo nickCheck(MemberVo memberVo);
+	MemberVo pNickCheck(MemberVo memberVo);
+	int jNickCheck(MemberVo memberVo);
 }

--- a/final-project/src/main/java/com/kh/finale/service/member/MemberFindService.java
+++ b/final-project/src/main/java/com/kh/finale/service/member/MemberFindService.java
@@ -9,5 +9,5 @@ public interface MemberFindService {
 	MemberVo findPw(MemberVo memberVo);
 	MemberAuthDto checkAuthEmail(MemberAuthDto memberAuthDto);
 	int idCheck(MemberVo memberVo);
-	int nickCheck(MemberVo memberVo);
+	MemberVo nickCheck(MemberVo memberVo);
 }

--- a/final-project/src/main/java/com/kh/finale/service/member/MemberFindServiceImpl.java
+++ b/final-project/src/main/java/com/kh/finale/service/member/MemberFindServiceImpl.java
@@ -40,7 +40,7 @@ public class MemberFindServiceImpl implements MemberFindService{
 	
 	// 회원가입 닉네임 중복값 검사
 	@Override
-	public int nickCheck(MemberVo memberVo) {
+	public MemberVo nickCheck(MemberVo memberVo) {
 		return memberDao.nickCheck(memberVo);
 	}
 	

--- a/final-project/src/main/java/com/kh/finale/service/member/MemberFindServiceImpl.java
+++ b/final-project/src/main/java/com/kh/finale/service/member/MemberFindServiceImpl.java
@@ -38,10 +38,16 @@ public class MemberFindServiceImpl implements MemberFindService{
 		return memberDao.idCheck(memberVo);
 	}
 	
-	// 회원가입 닉네임 중복값 검사
+	// 프로필 편집 닉네임 중복값 검사
 	@Override
-	public MemberVo nickCheck(MemberVo memberVo) {
-		return memberDao.nickCheck(memberVo);
+	public MemberVo pNickCheck(MemberVo memberVo) {
+		return memberDao.pNickCheck(memberVo);
+	}
+	
+	// 회원 가입 닉네임 중복값 검사
+	@Override
+	public int jNickCheck(MemberVo memberVo) {
+		return memberDao.jNickCheck(memberVo);
 	}
 	
 }

--- a/final-project/src/main/resources/mybatis/mapper/member/member-mapper.xml
+++ b/final-project/src/main/resources/mybatis/mapper/member/member-mapper.xml
@@ -64,9 +64,14 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		select count(*) from member where member_id = #{memberId}
 	</select>
 	
-	<!-- 닉네임 중복 체크 -->
-	<select id="nickCheck" parameterType="MemberVo" resultType="MemberVo">
+	<!-- 프로필 편집 닉네임 중복 체크 -->
+	<select id="pNickCheck" parameterType="MemberVo" resultType="MemberVo">
 		select member_nick from member where member_nick = #{memberNick}
+	</select>
+	
+	<!-- 회원가입 닉네임 중복 체크 -->
+	<select id="jNickCheck" parameterType="MemberVo" resultType="int">
+		select count(*) from member where member_nick = #{memberNick}
 	</select>
 	
 	<!-- 회원 탈퇴 -->

--- a/final-project/src/main/resources/mybatis/mapper/member/member-mapper.xml
+++ b/final-project/src/main/resources/mybatis/mapper/member/member-mapper.xml
@@ -65,8 +65,8 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 	</select>
 	
 	<!-- 닉네임 중복 체크 -->
-	<select id="nickCheck" parameterType="MemberVo" resultType="int">
-		select count(*) from member where member_nick = #{memberNick}
+	<select id="nickCheck" parameterType="MemberVo" resultType="MemberVo">
+		select member_nick from member where member_nick = #{memberNick}
 	</select>
 	
 	<!-- 회원 탈퇴 -->

--- a/final-project/src/main/webapp/WEB-INF/views/member/editProfile.jsp
+++ b/final-project/src/main/webapp/WEB-INF/views/member/editProfile.jsp
@@ -35,7 +35,7 @@
 				$("#nickck").addClass("text-success")
 				let memberNick = $(this).val();
 				$.ajax({
-					url:"nickCheck",
+					url:"pNickCheck",
 					data : {
 						memberNick : memberNick,
 					},

--- a/final-project/src/main/webapp/WEB-INF/views/member/join.jsp
+++ b/final-project/src/main/webapp/WEB-INF/views/member/join.jsp
@@ -88,7 +88,7 @@
 				$("#nickck").addClass("text-success")
 				let memberNick = $(this).val();
 				$.ajax({
-					url:"nickCheck",
+					url:"jNickCheck",
 					data : {
 						memberNick : memberNick,
 					},

--- a/final-project/src/test/java/com/kh/finale/report/PhotostoryReportTest.java
+++ b/final-project/src/test/java/com/kh/finale/report/PhotostoryReportTest.java
@@ -31,7 +31,7 @@ public class PhotostoryReportTest {
 	public void pReportInsert() {
 		PhotostoryReportDto photostoryReportDto = PhotostoryReportDto.builder()
 									.memberNo(112)
-									.pReportNo(2)
+									.pReportNo(16)
 									.pReportReason("부적절한 게시글")
 									.build();
 		photostoryReportService.pReportInsert(photostoryReportDto);


### PR DESCRIPTION
### 닉네임 중복 검사
 - 프로필 편집시 기존 닉네임을 그대로 사용하지 못하는 문제 해결
   - 회원 가입 닉네임 중복 검사와 프로필 편집 닉네임 중복 검사를 분리
   - 회원 가입 닉네임 중복 검사는 기존과 동일한 방식
   - 프로필 닉네임 중복 검사는 세션에서 회원 번호를 조회하여 닉네임을 가져오고 이를 조회값과 비교하여 처리

### 프로필 이미지 기능 수정
 - 프로필 편집시 이미지를 변경하지 않으면 이미지가 조회 되지 않는 문제
   - 프로필 업데이트시 이미지 파일이 있는지 검사하여 없는 경우에만 파일 업데이트 하도록 코드 수정