### PR TITLE
회원 정지 기능 및 인터셉터 구현 중

### DIFF
--- a/final-project/src/main/java/com/kh/finale/constant/MemberGradeConstant.java
+++ b/final-project/src/main/java/com/kh/finale/constant/MemberGradeConstant.java
@@ -1,0 +1,10 @@
+package com.kh.finale.constant;
+
+/**
+ * 회원 등급 상수 설정용 인터페이스
+ * @author swjk78
+ */
+public interface MemberGradeConstant {
+	int ADMIN = 1; // 관리자
+	int NORMAL = 2; // 일반회원
+}

--- a/final-project/src/main/java/com/kh/finale/controller/home/HomeController.java
+++ b/final-project/src/main/java/com/kh/finale/controller/home/HomeController.java
@@ -19,7 +19,7 @@ public class HomeController {
 	
 	@RequestMapping("/")
 	public String index(Model model, HttpSession session) {
-		// memberDto 전송
+		// 회원 정보 전송
 		if (session.getAttribute("memberNo") != null) {
 			MemberDto memberDto = memberDao.findInfo((int) session.getAttribute("memberNo"));
 			model.addAttribute("memberDto", memberDto);

--- a/final-project/src/main/java/com/kh/finale/controller/photostory/PhotostoryViewController.java
+++ b/final-project/src/main/java/com/kh/finale/controller/photostory/PhotostoryViewController.java
@@ -20,11 +20,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.kh.finale.entity.block.MemberBlockDto;
 import com.kh.finale.entity.member.MemberDto;
 import com.kh.finale.entity.photostory.PhotostoryCommentListDto;
 import com.kh.finale.entity.photostory.PhotostoryLikeDto;
 import com.kh.finale.entity.photostory.PhotostoryListDto;
 import com.kh.finale.entity.photostory.PhotostoryPhotoDto;
+import com.kh.finale.repository.block.MemberBlockDao;
 import com.kh.finale.repository.member.MemberDao;
 import com.kh.finale.repository.photostory.PhotostoryCommentListDao;
 import com.kh.finale.repository.photostory.PhotostoryDao;
@@ -59,6 +61,9 @@ public class PhotostoryViewController {
 	
 	@Autowired
 	private MemberDao memberDao;
+	
+	@Autowired
+	private MemberBlockDao memberBlockDao;
 
 	// 포토스토리 리스트 페이지
 	@GetMapping("")
@@ -66,12 +71,15 @@ public class PhotostoryViewController {
 		photostoryListVO = photostoryDao.getPageVariable(photostoryListVO);
 		List<PhotostoryListDto> photostoryList = photostoryListDao.list(photostoryListVO);
 		
-		// memberDto 전송
+		// 회원 정보 및 회원 정지 정보 전송
 		int memberNo = 0;
 		if (session.getAttribute("memberNo") != null) {
 			memberNo = (int) session.getAttribute("memberNo");
 			MemberDto memberDto = memberDao.findInfo(memberNo);
+			MemberBlockDto memberBlockDto = memberBlockDao.getBlockInfo(memberNo);
+			
 			model.addAttribute("memberDto", memberDto);
+			model.addAttribute("memberBlockDto", memberBlockDto);
 		}
 		
 		for (int i = 0; i < photostoryList.size(); i++) {
@@ -112,12 +120,15 @@ public class PhotostoryViewController {
 		PhotostoryListDto photostoryListDto = photostoryListDao.get(photostoryNo);
 		List<PhotostoryCommentListDto> photostoryCommentList = photostoryCommentListDao.list(photostoryNo);
 		
-		// memberDto 전송
+		// 회원 정보 및 회원 정지 정보 전송
 		int memberNo = 0;
 		if (session.getAttribute("memberNo") != null) {
 			memberNo = (int) session.getAttribute("memberNo");
 			MemberDto memberDto = memberDao.findInfo(memberNo);
+			MemberBlockDto memberBlockDto = memberBlockDao.getBlockInfo(memberNo);
+			
 			model.addAttribute("memberDto", memberDto);
+			model.addAttribute("memberBlockDto", memberBlockDto);
 		}
 		
 		// 이미지 리스트
@@ -143,7 +154,7 @@ public class PhotostoryViewController {
 	// 포토스토리 작성 페이지
 	@GetMapping("/write")
 	public String write(HttpSession session, Model model) {
-		// memberDto 전송
+		// 회원 정보 전송
 		if (session.getAttribute("memberNo") != null) {
 			MemberDto memberDto = memberDao.findInfo((int) session.getAttribute("memberNo"));
 			model.addAttribute("memberDto", memberDto);
@@ -176,7 +187,7 @@ public class PhotostoryViewController {
 		model.addAttribute("photostoryListDto", photostoryListDto);
 		model.addAttribute("photostoryPhotoList", photostoryPhotoList);
 		
-		// memberDto 전송
+		// 회원 정보 전송
 		MemberDto memberDto = memberDao.findInfo(photostoryListDto.getMemberNo());
 		model.addAttribute("memberDto", memberDto);
 		

--- a/final-project/src/main/java/com/kh/finale/entity/block/MemberBlockDto.java
+++ b/final-project/src/main/java/com/kh/finale/entity/block/MemberBlockDto.java
@@ -1,0 +1,23 @@
+package com.kh.finale.entity.block;
+
+import java.sql.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 회원 정지 기능에 필요한 변수를 저장하는 Dto
+ * @author swjk78
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberBlockDto {
+	private int blockNo, memberNo;
+	private Date blockStartDate;
+	private int blockPeriod;
+	private String blockContent, blockReason;
+}

--- a/final-project/src/main/java/com/kh/finale/interceptor/AdminInterceptor.java
+++ b/final-project/src/main/java/com/kh/finale/interceptor/AdminInterceptor.java
@@ -1,0 +1,38 @@
+package com.kh.finale.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.kh.finale.constant.MemberGradeConstant;
+import com.kh.finale.entity.member.MemberDto;
+import com.kh.finale.repository.member.MemberDao;
+
+/**
+ * 관리자 기능 접근 차단 인터셉터
+ * @author swjk78
+ */
+public class AdminInterceptor implements HandlerInterceptor {
+
+	@Autowired
+	private MemberDao memberDao;
+	
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		Integer memberNo = (Integer) request.getSession().getAttribute("memberNo");
+		
+		MemberDto memberDto = memberDao.findInfo(memberNo);
+		int memberGrade = memberDto.getMemberGrade();
+		
+		// 관리자가 아닐 경우
+		if (memberGrade != MemberGradeConstant.ADMIN) {
+			response.sendError(401);
+			
+			return false;
+		}
+		
+		return true;
+	}
+}

--- a/final-project/src/main/java/com/kh/finale/interceptor/MemberBlockInterceptor.java
+++ b/final-project/src/main/java/com/kh/finale/interceptor/MemberBlockInterceptor.java
@@ -1,0 +1,64 @@
+package com.kh.finale.interceptor;
+
+import java.util.Date;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.kh.finale.entity.block.MemberBlockDto;
+import com.kh.finale.entity.member.MemberDto;
+import com.kh.finale.repository.block.MemberBlockDao;
+import com.kh.finale.repository.member.MemberDao;
+import com.kh.finale.service.block.MemberBlockService;
+import com.kh.finale.util.DateUtils;
+
+/**
+ * 정지된 회원의 기능 사용 제한 인터셉터
+ * @author swjk78
+ *
+ */
+public class MemberBlockInterceptor implements HandlerInterceptor {
+
+	@Autowired
+	private MemberDao memberDao;
+
+	@Autowired
+	private MemberBlockDao memberBlockDao;
+	
+	@Autowired
+	private MemberBlockService memberBlockService;
+	
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		Integer memberNo = (Integer) request.getSession().getAttribute("memberNo");
+		
+		MemberDto memberDto = memberDao.findInfo(memberNo);
+		
+		// 정지 상태일 경우 처리
+		if (memberDto.getMemberState().equals("정지")) {
+			// 정지 해제 날짜 계산
+			MemberBlockDto memberBlockDto = memberBlockDao.getBlockInfo(memberNo);
+			Date blockStartDate = memberBlockDto.getBlockStartDate();
+			int blockPeriod = memberBlockDto.getBlockPeriod();
+			Date blockEndDate = DateUtils.plusDayToDate(blockStartDate, blockPeriod);
+			boolean blockCheck = DateUtils.compareWithSysdate(blockEndDate);
+			
+			// 정지 기간이 지났을 경우
+			if (blockCheck) {
+				memberBlockService.unblock(memberNo);
+			}
+			// 정지 기간이 지나지 않았을 경우
+			else {
+				// 어느 페이지로 보낼지, 보낸 후 어떤 알림창을 띄울 것인지 미정 
+				response.sendRedirect(request.getContextPath());
+				
+				return false;
+			}
+		}
+		
+		return true;
+	}
+}

--- a/final-project/src/main/java/com/kh/finale/interceptor/MemberLoginInterceptor.java
+++ b/final-project/src/main/java/com/kh/finale/interceptor/MemberLoginInterceptor.java
@@ -1,0 +1,27 @@
+package com.kh.finale.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * 회원 기능 접근 차단 인터셉터
+ * @author swjk78
+ */
+public class MemberLoginInterceptor implements HandlerInterceptor {
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		Integer memberNo = (Integer) request.getSession().getAttribute("memberNo");
+		
+		// 비로그인 상태일 때 처리
+		if (memberNo == null) {
+			// 어느 페이지로 보낼지, 보낸 후 어떤 알림창을 띄울 것인지 미정
+			response.sendRedirect(request.getContextPath() + "/member/login");
+			
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/final-project/src/main/java/com/kh/finale/interceptor/MemberLogoutInterceptor.java
+++ b/final-project/src/main/java/com/kh/finale/interceptor/MemberLogoutInterceptor.java
@@ -1,0 +1,28 @@
+package com.kh.finale.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * 비회원 기능 접근 차단 인터셉터
+ * @author swjk78
+ */
+public class MemberLogoutInterceptor implements HandlerInterceptor {
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		Integer memberNo = (Integer) request.getSession().getAttribute("memberNo");
+		
+		// 로그인 상태일 경우 처리
+		if (memberNo != null) {
+			// 어느 페이지로 보낼지, 보낸 후 어떤 알림창을 띄울 것인지 미정
+			response.sendRedirect(request.getContextPath());
+			
+			return false;
+		}
+		
+		return true;
+	}
+}

--- a/final-project/src/main/java/com/kh/finale/interceptor/PhotostoryEditInterceptor.java
+++ b/final-project/src/main/java/com/kh/finale/interceptor/PhotostoryEditInterceptor.java
@@ -1,0 +1,61 @@
+package com.kh.finale.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.kh.finale.constant.MemberGradeConstant;
+import com.kh.finale.entity.member.MemberDto;
+import com.kh.finale.entity.photostory.PhotostoryListDto;
+import com.kh.finale.repository.member.MemberDao;
+import com.kh.finale.repository.photostory.PhotostoryListDao;
+
+/**
+ * 포토스토리 편집 차단 인터셉터
+ * @author swjk78
+ */
+public class PhotostoryEditInterceptor implements HandlerInterceptor {
+
+	@Autowired
+	private MemberDao memberDao;
+	
+	@Autowired
+	private PhotostoryListDao photostoryListDao;
+	
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+		Integer memberNo = (Integer) request.getSession().getAttribute("memberNo");
+		
+		MemberDto memberDto = memberDao.findInfo(memberNo);
+		int memberGrade = memberDto.getMemberGrade();
+		
+		// 관리자가 아닐 경우
+		// 관리자가 회원들의 포토스토리 수정/삭제를 할 수 있는지 여부 미정
+		if (memberGrade != MemberGradeConstant.ADMIN) {
+			// 타인이 포토스토리 수정/삭제를 시도할 경우
+			int photostoryNo = Integer.parseInt(request.getParameter("photostoryNo"));
+			PhotostoryListDto photostoryListDto = photostoryListDao.get(photostoryNo);
+			
+			// 존재하지 않는 글일 경우
+			if (photostoryListDto == null) {
+				// 존재하지 않는 글이란 에러 페이지로 리다이렉트?
+				response.sendRedirect(request.getContextPath() + "/photostory");
+				
+				return false;
+			}
+			
+			// 타인의 글일 경우
+			int writerNo = photostoryListDto.getMemberNo();
+			if (writerNo != memberNo) {
+				// 403이 맞나?
+				response.sendError(403);
+				
+				return false;
+			}
+		}
+		
+		return true;
+	}
+}

--- a/final-project/src/main/java/com/kh/finale/repository/block/MemberBlockDao.java
+++ b/final-project/src/main/java/com/kh/finale/repository/block/MemberBlockDao.java
@@ -1,0 +1,14 @@
+package com.kh.finale.repository.block;
+
+import com.kh.finale.entity.block.MemberBlockDto;
+
+public interface MemberBlockDao {
+	// 회원 정지 정보 등록 기능
+	public void insertBlockInfo(MemberBlockDto memberBlockDto);
+
+	// 회원 정지 정보 삭제 기능
+	public void deleteBlockInfo(int memberNo);
+	
+	// 정지 정보 조회 기능
+	public MemberBlockDto getBlockInfo(int memberNo);
+}

--- a/final-project/src/main/java/com/kh/finale/repository/block/MemberBlockDaoImpl.java
+++ b/final-project/src/main/java/com/kh/finale/repository/block/MemberBlockDaoImpl.java
@@ -1,0 +1,32 @@
+package com.kh.finale.repository.block;
+
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import com.kh.finale.entity.block.MemberBlockDto;
+
+@Repository
+public class MemberBlockDaoImpl implements MemberBlockDao {
+
+	@Autowired
+	private SqlSession sqlSession;
+	
+	// 회원 정지 정보 등록 기능
+	@Override
+	public void insertBlockInfo(MemberBlockDto memberBlockDto) {
+		sqlSession.insert("memberBlock.insert", memberBlockDto);
+	}
+
+	// 회원 정지 정보 삭제 기능
+	@Override
+	public void deleteBlockInfo(int memberNo) {
+		sqlSession.delete("memberBlock.delete", memberNo);
+	}
+
+	// 정지 정보 조회 기능
+	@Override
+	public MemberBlockDto getBlockInfo(int memberNo) {
+		return sqlSession.selectOne("memberBlock.select", memberNo);
+	}
+}

--- a/final-project/src/main/java/com/kh/finale/repository/member/MemberDao.java
+++ b/final-project/src/main/java/com/kh/finale/repository/member/MemberDao.java
@@ -9,7 +9,7 @@ import com.kh.finale.vo.member.MemberVo;
 public interface MemberDao {
 	void join(MemberDto memberDto);
 	MemberDto login(MemberDto memberDto);
-	// 회원정보 조회(프로필 편집)
+	// 회원정보 조회(회원번호로)
 	MemberDto findInfo(int memberNo);
 	MemberDto findId(MemberDto memberDto);
 	MemberVo findPw(MemberVo memberVo);
@@ -22,4 +22,8 @@ public interface MemberDao {
 	int idCheck(MemberVo memberVo);
 	int nickCheck(MemberVo memberVo);
 	void exit(MemberVo memberVo);
+	// 회원 정지
+	void block(int memberNo);
+	// 회원 정지 해제
+	void unblock(int memberNo);
 }

--- a/final-project/src/main/java/com/kh/finale/repository/member/MemberDaoImpl.java
+++ b/final-project/src/main/java/com/kh/finale/repository/member/MemberDaoImpl.java
@@ -27,7 +27,7 @@ public class MemberDaoImpl implements MemberDao{
 		return sqlSession.selectOne("member.login", memberDto);
 	}
 
-	// 회원정보 조회(프로필 편집)
+	// 회원정보 조회(회원번호로)
 	@Override
 	public MemberDto findInfo(int memberNo) {
 		return sqlSession.selectOne("member.findInfo", memberNo);
@@ -89,4 +89,15 @@ public class MemberDaoImpl implements MemberDao{
 		sqlSession.delete("member.exit", memberVo);
 	}
 
+	// 회원 정지
+	@Override
+	public void block(int memberNo) {
+		sqlSession.update("member.block", memberNo);
+	}
+	
+	// 회원 정지 해제
+	@Override
+	public void unblock(int memberNo) {
+		sqlSession.update("member.unblock", memberNo);
+	}
 }

--- a/final-project/src/main/java/com/kh/finale/restcontroller/block/MemberBlockRestController.java
+++ b/final-project/src/main/java/com/kh/finale/restcontroller/block/MemberBlockRestController.java
@@ -1,0 +1,31 @@
+package com.kh.finale.restcontroller.block;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kh.finale.entity.block.MemberBlockDto;
+import com.kh.finale.service.block.MemberBlockService;
+
+@RestController
+@RequestMapping("/member_block")
+public class MemberBlockRestController {
+
+	@Autowired
+	private MemberBlockService memberBlockService;
+	
+	// 회원 정지 처리
+	@PostMapping("/block")
+	public void block(@ModelAttribute MemberBlockDto memberBlockDto) {
+		memberBlockService.block(memberBlockDto);
+	}
+	
+	// 회원 정지 해제 처리
+	@PostMapping("/unblock")
+	public void unblock(@RequestParam int memberNo) {
+		memberBlockService.unblock(memberNo);
+	}
+}

--- a/final-project/src/main/java/com/kh/finale/service/block/MemberBlockService.java
+++ b/final-project/src/main/java/com/kh/finale/service/block/MemberBlockService.java
@@ -1,0 +1,11 @@
+package com.kh.finale.service.block;
+
+import com.kh.finale.entity.block.MemberBlockDto;
+
+public interface MemberBlockService {
+	// 회원 정지
+	public void block(MemberBlockDto memberBlockDto);
+	
+	// 회원 정지 해제
+	public void unblock(int memberNo);
+}

--- a/final-project/src/main/java/com/kh/finale/service/block/MemberBlockServiceImpl.java
+++ b/final-project/src/main/java/com/kh/finale/service/block/MemberBlockServiceImpl.java
@@ -1,0 +1,35 @@
+package com.kh.finale.service.block;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kh.finale.entity.block.MemberBlockDto;
+import com.kh.finale.repository.block.MemberBlockDao;
+import com.kh.finale.repository.member.MemberDao;
+
+@Service
+public class MemberBlockServiceImpl implements MemberBlockService {
+
+	@Autowired
+	private MemberDao memberDao;
+	
+	@Autowired
+	private MemberBlockDao memberBlockDao;
+	
+	// 회원 정지
+	@Override
+	@Transactional
+	public void block(MemberBlockDto memberBlockDto) {
+		memberDao.block(memberBlockDto.getMemberNo());
+		memberBlockDao.insertBlockInfo(memberBlockDto);
+	}
+
+	// 회원 정지 해제
+	@Override
+	@Transactional
+	public void unblock(int memberNo) {
+		memberDao.unblock(memberNo);
+		memberBlockDao.deleteBlockInfo(memberNo);
+	}
+}

--- a/final-project/src/main/java/com/kh/finale/service/photostory/PhotostoryServiceImpl.java
+++ b/final-project/src/main/java/com/kh/finale/service/photostory/PhotostoryServiceImpl.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.kh.finale.entity.photostory.PhotostoryDto;
 import com.kh.finale.entity.photostory.PhotostoryPhotoDto;
@@ -25,6 +26,7 @@ public class PhotostoryServiceImpl implements PhotostoryService {
 	
 	// 포토스토리 등록
 	@Override
+	@Transactional
 	public void insertPhotostory(PhotostoryVO photostoryVO) throws IllegalStateException, IOException {
 		// 포토스토리 정보 등록
 		photostoryVO.setPhotostoryNo(photostoryDao.getSequence());
@@ -45,6 +47,7 @@ public class PhotostoryServiceImpl implements PhotostoryService {
 
 	// 포토스토리 수정
 	@Override
+	@Transactional
 	public void updatePhotostory(PhotostoryVO photostoryVO) throws IllegalStateException, IOException {
 		// 포토스토리 정보 수정
 		PhotostoryDto photostoryDto = PhotostoryDto.builder()
@@ -68,6 +71,7 @@ public class PhotostoryServiceImpl implements PhotostoryService {
 
 	// 포토스토리 삭제
 	@Override
+	@Transactional
 	public void deletePhotostory(int photostoryNo) {
 		deletePhotostoryPhoto(photostoryNo);
 		photostoryDao.deletePhotostory(photostoryNo);

--- a/final-project/src/main/java/com/kh/finale/util/DateUtils.java
+++ b/final-project/src/main/java/com/kh/finale/util/DateUtils.java
@@ -1,6 +1,7 @@
 package com.kh.finale.util;
 
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -11,7 +12,6 @@ import java.util.Date;
 public class DateUtils {
 
 	// 작성날짜와 현재날짜의 차이를 얻는 메소드
-	// (주의) sql.Date 타입으로 올 경우 시간/분/초 단위도 제대로 반환되는지 확인 필요
 	public static String getDifferenceInDate(Date inputDate) throws ParseException {
 		long currentTime = System.currentTimeMillis();
 		long compareTime = inputDate.getTime();
@@ -74,5 +74,30 @@ public class DateUtils {
 		}
 		
 		return yearString + monthString + dayString + hourString + minString + secString;
+	}
+	
+	// 입력받은 날짜에서 입력받은 일수를 더해서 반환하는 메소드
+	public static Date plusDayToDate(Date date, int day) {
+		// 입력받은 날짜를 Calendar로 변환
+		Calendar cal = Calendar.getInstance();
+		cal.setTime(date);
+		
+		// 일수 더하기
+		cal.add(Calendar.DAY_OF_MONTH, day);
+		
+		// Calendar를 Date로 변환
+		date = cal.getTime();
+		
+		return date;
+	}
+	
+	// 입력받은 날짜와 현재 시간을 비교하는 기능
+	public static boolean compareWithSysdate(Date inputDate) throws Exception {
+		SimpleDateFormat simpleDateformat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");				
+		String currentTime = simpleDateformat.format(System.currentTimeMillis());
+		Date sysdate = simpleDateformat.parse(currentTime);
+
+		// 입력 날짜가 현재 시간을 지났을 경우 true 반환
+		return inputDate.before(sysdate);
 	}
 }

--- a/final-project/src/main/resources/mybatis/mapper/block/memberBlock-mapper.xml
+++ b/final-project/src/main/resources/mybatis/mapper/block/memberBlock-mapper.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!DOCTYPE mapper
+PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+"https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="memberBlock">
+
+	<!-- 회원 정지 정보 등록 -->
+	<insert id="insert" parameterType="MemberBlockDto">
+		insert into member_block(block_no, member_no, block_period, block_content, block_reason)
+		values(member_block_seq.nextval, #{memberNo}, #{blockPeriod}, #{blockContent}, #{blockReason})
+	</insert>
+	
+	<!-- 회원 정지 정보 삭제 -->
+	<delete id="delete" parameterType="int">
+		delete member_block where member_no = #{memberNo}
+	</delete>
+	
+	<!-- 정지 정보 조회 -->
+	<select id="select" parameterType="int" resultType="MemberBlockDto">
+		select * from member_block where member_no = #{memberNo}
+	</select>
+	
+</mapper>

--- a/final-project/src/main/resources/mybatis/mapper/member/member-mapper.xml
+++ b/final-project/src/main/resources/mybatis/mapper/member/member-mapper.xml
@@ -23,9 +23,9 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 			and member_pw = #{memberPw}
 	</select>
 	
-	<!-- 회원정보 조회(프로필 편집) -->
+	<!-- 회원정보 조회(회원번호로) -->
 	<select id="findInfo" parameterType="int" resultType="MemberDto">
-		select member_nick, member_name, member_email, member_gender, member_intro
+		select member_nick, member_email, member_name, member_gender, member_grade, member_intro, member_state
 		from member where member_no = #{memberNo}
 	</select>
 	
@@ -73,4 +73,15 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 	<delete id="exit" parameterType="MemberVo">
 		delete from member where member_id = #{memberId}
 	</delete>
+	
+	<!-- 회원 정지 -->
+	<update id="block" parameterType="int">
+		update member set member_state = '정지' where member_no = #{memberNo}
+	</update>
+	
+	<!-- 회원 정지 해제 -->
+	<update id="unblock" parameterType="int">
+		update member set member_state = '정상' where member_no = #{memberNo}
+	</update>
+	
 </mapper>

--- a/final-project/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/final-project/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -62,4 +62,54 @@
 		<beans:property name="maxUploadSize" value="100000000"></beans:property>
 		<beans:property name="maxUploadSizePerFile" value="10000000"></beans:property>
 	</beans:bean>
+	
+	<!-- 인터셉터 등록 -->
+	<interceptors>
+		
+		<!-- 회원 기능 접근 차단 인터셉터 -->
+		<interceptor>
+			<mapping path="/photostory/**"/>
+			<mapping path="/process/**"/>
+			<mapping path="/member/logout"/>
+			<mapping path="/member/editProfile"/>
+			<mapping path="/member/exit"/>
+			<exclude-mapping path="/photostory"/>
+			<exclude-mapping path="/photostory/detail"/>
+			<beans:bean class="com.kh.finale.interceptor.MemberLoginInterceptor"></beans:bean>
+		</interceptor>
+		
+		<!-- 비회원 기능 접근 차단 인터셉터 -->
+		<interceptor>
+			<mapping path="/member/**"/>
+			<exclude-mapping path="/member/idCheck"/>
+			<exclude-mapping path="/member/nickCheck"/>
+			<exclude-mapping path="/member/logout"/>
+			<exclude-mapping path="/member/editProfile"/>
+			<exclude-mapping path="/member/exit"/>
+			<beans:bean class="com.kh.finale.interceptor.MemberLogoutInterceptor"></beans:bean>
+		</interceptor>
+		
+		<!-- 정지된 회원의 기능 사용 제한 인터셉터 -->
+		<interceptor>
+			<mapping path="/photostory/**"/>
+			<mapping path="/process/**"/>
+			<exclude-mapping path="/photostory"/>
+			<exclude-mapping path="/photostory/detail"/>
+			<beans:bean class="com.kh.finale.interceptor.MemberBlockInterceptor"></beans:bean>
+		</interceptor>
+		
+		<!-- 포토스토리 편집 차단 인터셉터 -->
+		<interceptor>
+			<mapping path="/photostory/edit"/>
+			<mapping path="/photostory/delete"/>
+			<beans:bean class="com.kh.finale.interceptor.PhotostoryEditInterceptor"></beans:bean>
+		</interceptor>
+
+		<!-- 관리자 기능 접근 차단 인터셉터 -->
+		<interceptor>
+			<mapping path="/admin/**"/>
+			<beans:bean class="com.kh.finale.interceptor.AdminInterceptor"></beans:bean>
+		</interceptor>
+		
+	</interceptors>
 </beans:beans>

--- a/final-project/src/test/java/com/kh/finale/block/MemberBlockTest.java
+++ b/final-project/src/test/java/com/kh/finale/block/MemberBlockTest.java
@@ -1,0 +1,46 @@
+package com.kh.finale.block;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import com.kh.finale.entity.block.MemberBlockDto;
+import com.kh.finale.service.block.MemberBlockService;
+
+/**
+ * 회원 정지 관련 테스트
+ * @author swjk78
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {
+	"file:src/main/webapp/WEB-INF/spring/root-context.xml",
+	"file:src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml"
+})
+@WebAppConfiguration
+public class MemberBlockTest {
+
+	@Autowired
+	private MemberBlockService memberBlockService;
+	
+	// 정지 테스트
+	@Test
+	public void block() {
+		MemberBlockDto memberBlockDto = MemberBlockDto.builder()
+				.memberNo(119)
+				.blockPeriod(1)
+				.blockContent("차단글 내용")
+				.blockReason("차단 이유")
+				.build();
+		memberBlockService.block(memberBlockDto);
+	}
+	
+	// 정지 해제 테스트
+//	@Test
+//	public void unblock() {
+//		int memberNo = 119;
+//		memberBlockService.unblock(memberNo);
+//	}
+}

--- a/final-project/src/test/java/com/kh/finale/photostory/PhotostoryListTest.java
+++ b/final-project/src/test/java/com/kh/finale/photostory/PhotostoryListTest.java
@@ -32,10 +32,10 @@ import lombok.extern.slf4j.Slf4j;
 public class PhotostoryListTest {
 
 	@Autowired
-	PhotostoryListDao photostoryListDao;
+	private PhotostoryListDao photostoryListDao;
 	
 	@Autowired
-	PhotostoryCommentListDao photostoryCommentListDao;
+	private PhotostoryCommentListDao photostoryCommentListDao;
 	
 	@Test
 	public void test() {

--- a/final-project/src/test/java/com/kh/finale/util/DateUtilsTest.java
+++ b/final-project/src/test/java/com/kh/finale/util/DateUtilsTest.java
@@ -1,8 +1,7 @@
 package com.kh.finale.util;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Date;
 
 import org.junit.Test;
 
@@ -50,32 +49,45 @@ public class DateUtilsTest {
 //		log.debug("msg = {}", msg);
 //	}
 	
+//	@Test
+//	public void getSysdate() {
+//		Calendar cal = Calendar.getInstance();
+//		
+//		String year = String.valueOf(cal.get(Calendar.YEAR));
+//		
+//		int monthInt = cal.get(Calendar.MONTH) + 1;
+//		String month;
+//		
+//		if (monthInt < 10) {
+//			month = "0" + String.valueOf(monthInt);
+//		} else {
+//			month = String.valueOf(monthInt);
+//		}
+//		
+//		String day;
+//		int dayInt = cal.get(Calendar.DAY_OF_MONTH);
+//		
+//		if (dayInt < 10) {
+//			day = "0" + String.valueOf(dayInt);
+//		} else {
+//			day = String.valueOf(dayInt);
+//		}
+//		
+//		String msg = year + month + day;
+//		
+//		log.debug("결과: {}", msg);
+//	}
+	
 	@Test
-	public void getSysdate() {
+	public void test() {
 		Calendar cal = Calendar.getInstance();
 		
-		String year = String.valueOf(cal.get(Calendar.YEAR));
+		// 일수 더하기
+		cal.add(Calendar.DAY_OF_MONTH, 365);
 		
-		int monthInt = cal.get(Calendar.MONTH) + 1;
-		String month;
+		// Calendar를 Date로 변환
+		Date date = cal.getTime();
 		
-		if (monthInt < 10) {
-			month = "0" + String.valueOf(monthInt);
-		} else {
-			month = String.valueOf(monthInt);
-		}
-		
-		String day;
-		int dayInt = cal.get(Calendar.DAY_OF_MONTH);
-		
-		if (dayInt < 10) {
-			day = "0" + String.valueOf(dayInt);
-		} else {
-			day = String.valueOf(dayInt);
-		}
-		
-		String msg = year + month + day;
-		
-		log.debug("결과: {}", msg);
+		log.debug("date = {}", date);
 	}
 }


### PR DESCRIPTION
<h2>구현 중인 회원 정지 기능</h2>
<li>프론트단에서 정지된 회원의 좋아요, 댓글 등록 방지 필요(memberBlockDto로 정지 여부 판별 가능)</li>
<li>회원 정지 기능 구조 개선 필요(인터셉터에 있는 정지 해제 날짜 계산 코드를 MemberBlockDao로 이동)</li>

<h2>구현 중인 인터셉터</h2>
<li>회원 기능 접근 차단 인터셉터</li>
<li>비회원 기능 접근 차단 인터셉터</li>
<li>정지된 회원의 기능 사용 제한 인터셉터</li>
<li>포토스토리 편집 차단 인터셉터</li>
<li>관리자 기능 접근 차단 인터셉터</li>

<h2>협의가 필요한 사항</h2>
<li>관리자가 회원들의 포토스토리 수정/삭제를 할 수 있는지 여부</li>
<li>정지된 회원의 경우 정확히 어떤 기능을 제한할 지 결정 필요</li>
<li>인터셉터에서 어느 페이지로 보낼지, 보낸 후 어떤 알림창을 띄울 것인지</li>
<li>HomeController, MemberController 정리</li>
<li>마이페이지 주소 수정</li>