### PR TITLE
마이페이지 구조 개선 및 회원 정지 기능 구현 중

### DIFF
--- a/final-project/src/main/java/com/kh/finale/controller/home/HomeController.java
+++ b/final-project/src/main/java/com/kh/finale/controller/home/HomeController.java
@@ -2,20 +2,19 @@ package com.kh.finale.controller.home;
 
 import javax.servlet.http.HttpSession;
 
-import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import com.kh.finale.entity.member.FollowDto;
 import com.kh.finale.entity.member.MemberDto;
-import com.kh.finale.repository.member.FollowDao;
 import com.kh.finale.repository.member.MemberDao;
 
 @Controller
 public class HomeController {
+	
+	@Autowired
+	private MemberDao memberDao;
 	
 	@RequestMapping("/")
 	public String index(Model model, HttpSession session) {
@@ -26,50 +25,6 @@ public class HomeController {
 		}
 		
 		return "home"; 
-	}
-	
-	@Autowired
-	private SqlSession sqlSession;
-	
-	// 마이페이지 조회
-	@Autowired
-	private FollowDao followDao;
-	@RequestMapping("/member/{memberNick}")
-	public String myPage(@PathVariable String memberNick
-			,Model model,HttpSession session) {
-		MemberDto memberDto = sqlSession.selectOne("findWithNick",memberNick);
-		model.addAttribute("memberDto",memberDto);
-		
-		boolean isFollow = false;
-		
-		if((Integer)session.getAttribute("memberNo")!=null) {
-			FollowDto followDto = FollowDto.builder()
-					.followFrom((Integer)session.getAttribute("memberNo"))
-					.followTo(memberDto.getMemberNo())
-					.build();
-			if(followDao.isFollow(followDto)!=null) {
-				isFollow=true;
-			}
-		}
-		
-		model.addAttribute("isFollow",isFollow);
-		model.addAttribute("countFollower",followDao.getCountFollower(memberDto.getMemberNo()));
-		model.addAttribute("countFollowing",followDao.getCountFollowing(memberDto.getMemberNo()));
-		return "member/myPage";
-	}
-	
-	// 맴버 프로필 편집
-	@Autowired
-	HttpSession httpSession;
-	
-	@Autowired
-	private MemberDao memberDao;
-	
-	@RequestMapping("/member/editProfile")
-	public String editProfile(Model model) {
-		MemberDto memberDto = memberDao.findInfo((int) httpSession.getAttribute("memberNo"));
-		model.addAttribute("memberDto", memberDto);
-		return "member/editProfile"; 
 	}
 	
 	// 관리자 페이지

--- a/final-project/src/main/java/com/kh/finale/controller/member/MemberController.java
+++ b/final-project/src/main/java/com/kh/finale/controller/member/MemberController.java
@@ -21,15 +21,19 @@ import org.springframework.ui.Model;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
 
+import com.kh.finale.entity.block.MemberBlockDto;
+import com.kh.finale.entity.member.FollowDto;
 import com.kh.finale.entity.member.MemberAuthDto;
 import com.kh.finale.entity.member.MemberDto;
 import com.kh.finale.entity.member.MemberProfileDto;
+import com.kh.finale.repository.member.FollowDao;
 import com.kh.finale.repository.member.MemberDao;
 import com.kh.finale.repository.member.MemberProfileDao;
 import com.kh.finale.service.member.MemberAuthService;
@@ -87,7 +91,7 @@ public class MemberController {
 	}
 
 	// 프로필 편집 닉네임 중복체크
-	@PostMapping("/pNickCheck")
+	@PostMapping("/profile/pNickCheck")
 	@ResponseBody
 	public boolean pNickCheck(@ModelAttribute MemberVo memberVo, HttpSession httpSession) {
 		System.out.println("닉네임 중복값 체크 : " + memberVo);
@@ -163,7 +167,15 @@ public class MemberController {
 
 	// 비밀번호 찾기 페이지
 	@GetMapping("/findPw")
-	public String findPw() {
+	public String findPw(HttpSession session, Model model) {
+		// 회원 정보 전송
+		int memberNo = 0;
+		if (session.getAttribute("memberNo") != null) {
+			memberNo = (int) session.getAttribute("memberNo");
+			MemberDto memberDto = memberDao.findInfo(memberNo);
+			
+			model.addAttribute("memberDto", memberDto);
+		}
 		return "member/findPw";
 	}
 
@@ -231,7 +243,37 @@ public class MemberController {
 		return "redirect:/";
 	}
 
-	// 마이페이지 이미지 출력
+	// 마이페이지 조회
+	@Autowired
+	private FollowDao followDao;
+	@RequestMapping("/profile/{memberNick}")
+	public String myPage(@PathVariable String memberNick
+			,Model model,HttpSession session) {
+		// 마이페이지 회원 정보 전송
+		MemberDto memberDto = memberDao.findWithNick(memberNick);
+		model.addAttribute("profileMemberDto", memberDto);
+		
+		boolean isFollow = false;
+		
+		if((Integer)session.getAttribute("memberNo")!=null) {
+			// 회원 정보 전송
+			memberDto = memberDao.findInfo((int) session.getAttribute("memberNo"));
+			model.addAttribute("memberDto", memberDto);
+			
+			FollowDto followDto = FollowDto.builder()
+					.followFrom((Integer)session.getAttribute("memberNo"))
+					.followTo(memberDto.getMemberNo())
+					.build();
+			if(followDao.isFollow(followDto)!=null) {
+				isFollow=true;
+			}
+		}
+		
+		model.addAttribute("isFollow",isFollow);
+		model.addAttribute("countFollower",followDao.getCountFollower(memberDto.getMemberNo()));
+		model.addAttribute("countFollowing",followDao.getCountFollowing(memberDto.getMemberNo()));
+		return "member/myPage";
+	}
 
 	@Autowired
 	MemberProfileDao memberProfileDao;
@@ -239,7 +281,8 @@ public class MemberController {
 	@Autowired
 	HttpSession httpSession;
 
-	@GetMapping("/profileImage")
+	// 마이페이지 이미지 출력
+	@GetMapping("/profile/profileImage")
 	public ResponseEntity<ByteArrayResource> image() throws IOException {
 		String memberId = (String) httpSession.getAttribute("memberId");
 		System.out.println("아이디 값 :" + memberId);
@@ -260,11 +303,19 @@ public class MemberController {
 				.body(resource);
 	}
 
+	// 프로필 편집 페이지
+	@GetMapping("/profile/editProfile")
+	public String editProfile(Model model) {
+		MemberDto memberDto = memberDao.findInfo((int) httpSession.getAttribute("memberNo"));
+		model.addAttribute("memberDto", memberDto);
+		return "member/editProfile"; 
+	}
+	
 	@Autowired
 	MemberEditService memberEditService;
 
-	// 프로필 편집
-	@PostMapping("/editProfile")
+	// 프로필 편집 처리
+	@PostMapping("/profile/editProfile")
 	public String editProfile(@ModelAttribute MemberVo memberVo, HttpSession httpSession) throws IllegalStateException, IOException {
 		System.out.println("수신값 검사 : " + memberVo);
 		memberVo.setMemberNo((int) httpSession.getAttribute("memberNo"));

--- a/final-project/src/main/java/com/kh/finale/controller/member/MemberController.java
+++ b/final-project/src/main/java/com/kh/finale/controller/member/MemberController.java
@@ -28,7 +28,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
 
-import com.kh.finale.entity.block.MemberBlockDto;
 import com.kh.finale.entity.member.FollowDto;
 import com.kh.finale.entity.member.MemberAuthDto;
 import com.kh.finale.entity.member.MemberDto;

--- a/final-project/src/main/java/com/kh/finale/entity/block/MemberBlockDto.java
+++ b/final-project/src/main/java/com/kh/finale/entity/block/MemberBlockDto.java
@@ -20,4 +20,6 @@ public class MemberBlockDto {
 	private Date blockStartDate;
 	private int blockPeriod;
 	private String blockContent, blockReason;
+	
+	private Date blockEndDate;
 }

--- a/final-project/src/main/java/com/kh/finale/interceptor/AdminInterceptor.java
+++ b/final-project/src/main/java/com/kh/finale/interceptor/AdminInterceptor.java
@@ -10,10 +10,13 @@ import com.kh.finale.constant.MemberGradeConstant;
 import com.kh.finale.entity.member.MemberDto;
 import com.kh.finale.repository.member.MemberDao;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * 관리자 기능 접근 차단 인터셉터
  * @author swjk78
  */
+@Slf4j
 public class AdminInterceptor implements HandlerInterceptor {
 
 	@Autowired
@@ -29,6 +32,7 @@ public class AdminInterceptor implements HandlerInterceptor {
 		// 관리자가 아닐 경우
 		if (memberGrade != MemberGradeConstant.ADMIN) {
 			response.sendError(401);
+			log.debug("인터셉터: AdminInterceptor 차단");
 			
 			return false;
 		}

--- a/final-project/src/main/java/com/kh/finale/interceptor/MemberBlockInterceptor.java
+++ b/final-project/src/main/java/com/kh/finale/interceptor/MemberBlockInterceptor.java
@@ -1,25 +1,24 @@
 package com.kh.finale.interceptor;
 
-import java.util.Date;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import com.kh.finale.entity.block.MemberBlockDto;
 import com.kh.finale.entity.member.MemberDto;
 import com.kh.finale.repository.block.MemberBlockDao;
 import com.kh.finale.repository.member.MemberDao;
 import com.kh.finale.service.block.MemberBlockService;
-import com.kh.finale.util.DateUtils;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 정지된 회원의 기능 사용 제한 인터셉터
  * @author swjk78
  *
  */
+@Slf4j
 public class MemberBlockInterceptor implements HandlerInterceptor {
 
 	@Autowired
@@ -39,12 +38,8 @@ public class MemberBlockInterceptor implements HandlerInterceptor {
 		
 		// 정지 상태일 경우 처리
 		if (memberDto.getMemberState().equals("정지")) {
-			// 정지 해제 날짜 계산
-			MemberBlockDto memberBlockDto = memberBlockDao.getBlockInfo(memberNo);
-			Date blockStartDate = memberBlockDto.getBlockStartDate();
-			int blockPeriod = memberBlockDto.getBlockPeriod();
-			Date blockEndDate = DateUtils.plusDayToDate(blockStartDate, blockPeriod);
-			boolean blockCheck = DateUtils.compareWithSysdate(blockEndDate);
+			// 정지 해제 체크
+			boolean blockCheck = memberBlockDao.checkBlock(memberNo);
 			
 			// 정지 기간이 지났을 경우
 			if (blockCheck) {
@@ -53,7 +48,8 @@ public class MemberBlockInterceptor implements HandlerInterceptor {
 			// 정지 기간이 지나지 않았을 경우
 			else {
 				// 어느 페이지로 보낼지, 보낸 후 어떤 알림창을 띄울 것인지 미정 
-				response.sendRedirect(request.getContextPath());
+				response.sendRedirect(request.getContextPath() + "?block");
+				log.debug("인터셉터: MemberBlockInterceptor 차단");
 				
 				return false;
 			}

--- a/final-project/src/main/java/com/kh/finale/interceptor/MemberLoginInterceptor.java
+++ b/final-project/src/main/java/com/kh/finale/interceptor/MemberLoginInterceptor.java
@@ -5,10 +5,13 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * 비회원의 회원 기능 접근 차단 인터셉터
  * @author swjk78
  */
+@Slf4j
 public class MemberLoginInterceptor implements HandlerInterceptor {
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
@@ -18,6 +21,7 @@ public class MemberLoginInterceptor implements HandlerInterceptor {
 		if (memberNo == null) {
 			// 어느 페이지로 보낼지, 보낸 후 어떤 알림창을 띄울 것인지 미정
 			response.sendRedirect(request.getContextPath() + "/member/login");
+			log.debug("인터셉터: MemberLoginInterceptor 차단");
 			
 			return false;
 		}

--- a/final-project/src/main/java/com/kh/finale/interceptor/MemberLogoutInterceptor.java
+++ b/final-project/src/main/java/com/kh/finale/interceptor/MemberLogoutInterceptor.java
@@ -5,10 +5,13 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.web.servlet.HandlerInterceptor;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * 회원의 비회원 기능 접근 차단 인터셉터
  * @author swjk78
  */
+@Slf4j
 public class MemberLogoutInterceptor implements HandlerInterceptor {
 
 	@Override
@@ -19,6 +22,7 @@ public class MemberLogoutInterceptor implements HandlerInterceptor {
 		if (memberNo != null) {
 			// 어느 페이지로 보낼지, 보낸 후 어떤 알림창을 띄울 것인지 미정
 			response.sendRedirect(request.getContextPath());
+			log.debug("인터셉터: MemberLogoutInterceptor 차단");
 			
 			return false;
 		}

--- a/final-project/src/main/java/com/kh/finale/interceptor/PhotostoryEditInterceptor.java
+++ b/final-project/src/main/java/com/kh/finale/interceptor/PhotostoryEditInterceptor.java
@@ -12,10 +12,13 @@ import com.kh.finale.entity.photostory.PhotostoryListDto;
 import com.kh.finale.repository.member.MemberDao;
 import com.kh.finale.repository.photostory.PhotostoryListDao;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * 포토스토리 편집 차단 인터셉터
  * @author swjk78
  */
+@Slf4j
 public class PhotostoryEditInterceptor implements HandlerInterceptor {
 
 	@Autowired
@@ -42,6 +45,7 @@ public class PhotostoryEditInterceptor implements HandlerInterceptor {
 			if (photostoryListDto == null) {
 				// 존재하지 않는 글이란 에러 페이지로 리다이렉트?
 				response.sendRedirect(request.getContextPath() + "/photostory");
+				log.debug("인터셉터: PhotostoryEditInterceptor 차단");
 				
 				return false;
 			}
@@ -51,6 +55,7 @@ public class PhotostoryEditInterceptor implements HandlerInterceptor {
 			if (writerNo != memberNo) {
 				// 403이 맞나?
 				response.sendError(403);
+				log.debug("인터셉터: PhotostoryEditInterceptor 차단");
 				
 				return false;
 			}

--- a/final-project/src/main/java/com/kh/finale/repository/block/MemberBlockDao.java
+++ b/final-project/src/main/java/com/kh/finale/repository/block/MemberBlockDao.java
@@ -4,11 +4,14 @@ import com.kh.finale.entity.block.MemberBlockDto;
 
 public interface MemberBlockDao {
 	// 회원 정지 정보 등록 기능
-	public void insertBlockInfo(MemberBlockDto memberBlockDto);
+	void insertBlockInfo(MemberBlockDto memberBlockDto);
 
 	// 회원 정지 정보 삭제 기능
-	public void deleteBlockInfo(int memberNo);
+	void deleteBlockInfo(int memberNo);
 	
 	// 정지 정보 조회 기능
-	public MemberBlockDto getBlockInfo(int memberNo);
+	MemberBlockDto getBlockInfo(int memberNo);
+	
+	// 정지 해제 체크 기능
+	boolean checkBlock(int memberNo) throws Exception;
 }

--- a/final-project/src/main/java/com/kh/finale/repository/block/MemberBlockDaoImpl.java
+++ b/final-project/src/main/java/com/kh/finale/repository/block/MemberBlockDaoImpl.java
@@ -1,10 +1,13 @@
 package com.kh.finale.repository.block;
 
+import java.util.Date;
+
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import com.kh.finale.entity.block.MemberBlockDto;
+import com.kh.finale.util.DateUtils;
 
 @Repository
 public class MemberBlockDaoImpl implements MemberBlockDao {
@@ -28,5 +31,18 @@ public class MemberBlockDaoImpl implements MemberBlockDao {
 	@Override
 	public MemberBlockDto getBlockInfo(int memberNo) {
 		return sqlSession.selectOne("memberBlock.select", memberNo);
+	}
+	
+	// 정지 해제 체크 기능
+	// - 정지 해제 날짜가 지났으면 true 반환
+	@Override
+	public boolean checkBlock(int memberNo) throws Exception {
+		// 회원 정지 정보 및 정지 해제 날짜 조회
+		MemberBlockDto memberBlockDto = getBlockInfo(memberNo);
+		
+		// 정지 해제 날짜 계산
+		Date blockEndDate = memberBlockDto.getBlockEndDate();
+		
+		return DateUtils.compareWithSysdate(blockEndDate);
 	}
 }

--- a/final-project/src/main/java/com/kh/finale/repository/member/MemberDao.java
+++ b/final-project/src/main/java/com/kh/finale/repository/member/MemberDao.java
@@ -13,6 +13,8 @@ public interface MemberDao {
 	MemberDto findInfo(int memberNo);
 	MemberDto findId(MemberDto memberDto);
 	MemberVo findPw(MemberVo memberVo);
+	// 회원정보 조회(닉네임으로)
+	MemberDto findWithNick(String memberNick);
 	void authInsert(MemberAuthDto memberAuthDto);
 	Map<String,Object> resultAuth(MemberAuthDto memberAuthDto);
 	MemberAuthDto checkAuthEmail(MemberAuthDto memberAuthDto);

--- a/final-project/src/main/java/com/kh/finale/repository/member/MemberDaoImpl.java
+++ b/final-project/src/main/java/com/kh/finale/repository/member/MemberDaoImpl.java
@@ -42,6 +42,12 @@ public class MemberDaoImpl implements MemberDao{
 	public MemberVo findPw(MemberVo memberVo) {
 		return sqlSession.selectOne("member.findPw", memberVo);
 	}
+	
+	// 회원 정보 조회(닉네임으로)
+	@Override
+	public MemberDto findWithNick(String memberNick) {
+		return sqlSession.selectOne("member.findWithNick", memberNick);
+	}
 
 	@Override
 	public void authInsert(MemberAuthDto memberAuthDto) {

--- a/final-project/src/main/java/com/kh/finale/restcontroller/block/MemberBlockRestController.java
+++ b/final-project/src/main/java/com/kh/finale/restcontroller/block/MemberBlockRestController.java
@@ -1,5 +1,7 @@
 package com.kh.finale.restcontroller.block;
 
+import java.sql.Date;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -8,12 +10,17 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kh.finale.entity.block.MemberBlockDto;
+import com.kh.finale.repository.block.MemberBlockDao;
 import com.kh.finale.service.block.MemberBlockService;
+import com.kh.finale.util.DateUtils;
 
 @RestController
 @RequestMapping("/member_block")
 public class MemberBlockRestController {
 
+	@Autowired
+	private MemberBlockDao memberBlockDao;
+	
 	@Autowired
 	private MemberBlockService memberBlockService;
 	
@@ -21,6 +28,13 @@ public class MemberBlockRestController {
 	@PostMapping("/block")
 	public void block(@ModelAttribute MemberBlockDto memberBlockDto) {
 		memberBlockService.block(memberBlockDto);
+		
+		// 정지 해제 날짜 계산 및 설정
+		memberBlockDto = memberBlockDao.getBlockInfo(memberBlockDto.getMemberNo());
+		Date blockEndDate = DateUtils.formatToSqlDate(
+				DateUtils.plusDayToDate(memberBlockDto.getBlockStartDate(), memberBlockDto.getBlockPeriod())
+		);
+		memberBlockDto.setBlockEndDate(blockEndDate);
 	}
 	
 	// 회원 정지 해제 처리

--- a/final-project/src/main/java/com/kh/finale/service/block/MemberBlockServiceImpl.java
+++ b/final-project/src/main/java/com/kh/finale/service/block/MemberBlockServiceImpl.java
@@ -1,7 +1,5 @@
 package com.kh.finale.service.block;
 
-import java.sql.Date;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,7 +7,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kh.finale.entity.block.MemberBlockDto;
 import com.kh.finale.repository.block.MemberBlockDao;
 import com.kh.finale.repository.member.MemberDao;
-import com.kh.finale.util.DateUtils;
 
 @Service
 public class MemberBlockServiceImpl implements MemberBlockService {

--- a/final-project/src/main/java/com/kh/finale/service/block/MemberBlockServiceImpl.java
+++ b/final-project/src/main/java/com/kh/finale/service/block/MemberBlockServiceImpl.java
@@ -1,5 +1,7 @@
 package com.kh.finale.service.block;
 
+import java.sql.Date;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kh.finale.entity.block.MemberBlockDto;
 import com.kh.finale.repository.block.MemberBlockDao;
 import com.kh.finale.repository.member.MemberDao;
+import com.kh.finale.util.DateUtils;
 
 @Service
 public class MemberBlockServiceImpl implements MemberBlockService {

--- a/final-project/src/main/java/com/kh/finale/util/DateUtils.java
+++ b/final-project/src/main/java/com/kh/finale/util/DateUtils.java
@@ -103,8 +103,6 @@ public class DateUtils {
 	
 	// java.util.Date에서 java.sql.Date로 변환하는 메소드
 	public static java.sql.Date formatToSqlDate(Date date) {
-		java.sql.Date result = new java.sql.Date(date.getTime());
-		
-		return result;
+		return new java.sql.Date(date.getTime());
 	}
 }

--- a/final-project/src/main/java/com/kh/finale/util/DateUtils.java
+++ b/final-project/src/main/java/com/kh/finale/util/DateUtils.java
@@ -100,4 +100,11 @@ public class DateUtils {
 		// 입력 날짜가 현재 시간을 지났을 경우 true 반환
 		return inputDate.before(sysdate);
 	}
+	
+	// java.util.Date에서 java.sql.Date로 변환하는 메소드
+	public static java.sql.Date formatToSqlDate(Date date) {
+		java.sql.Date result = new java.sql.Date(date.getTime());
+		
+		return result;
+	}
 }

--- a/final-project/src/main/java/com/kh/finale/util/DateUtils.java
+++ b/final-project/src/main/java/com/kh/finale/util/DateUtils.java
@@ -11,7 +11,7 @@ import java.util.Date;
  */
 public class DateUtils {
 
-	// 작성날짜와 현재날짜의 차이를 얻는 메소드
+	// 작성 경과 시간을 반환하는 메소드
 	public static String getDifferenceInDate(Date inputDate) throws ParseException {
 		long currentTime = System.currentTimeMillis();
 		long compareTime = inputDate.getTime();
@@ -36,7 +36,7 @@ public class DateUtils {
 		return msg;
 	}
 	
-	// 현재 연도월일시분초를 반환하는 메소드
+	// 현재 연도월일시분초를 문자열로 반환하는 메소드
 	public static String getDateString() {
 		Calendar cal = Calendar.getInstance();
 		

--- a/final-project/src/main/java/com/kh/finale/vo/photostory/PhotostoryListVO.java
+++ b/final-project/src/main/java/com/kh/finale/vo/photostory/PhotostoryListVO.java
@@ -15,6 +15,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class PhotostoryListVO {
 	private int startRow, endRow, pageNo, pageSize;
-	private String searchType, searchKeyword;
+	private String searchKeyword;
 	private int startBlock, endBlock, lastBlock;
 }

--- a/final-project/src/main/resources/mybatis/mapper/member/member-mapper.xml
+++ b/final-project/src/main/resources/mybatis/mapper/member/member-mapper.xml
@@ -43,8 +43,7 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 	
 	<!-- 닉네임으로 회원 조회 -->
 	<select id="findWithNick" parameterType="String" resultType="MemberDto"> 
-		select * from member where 
-		member_nick = #{memberNick}
+		select * from member where member_nick = #{memberNick}
 	</select>
 	
 	<!-- 비밀번호 변경 -->

--- a/final-project/src/main/resources/mybatis/mapper/photostory/photostoryCommentList-mapper.xml
+++ b/final-project/src/main/resources/mybatis/mapper/photostory/photostoryCommentList-mapper.xml
@@ -9,6 +9,7 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 	<!-- 포토스토리 댓글 리스트 조회 -->
 	<select id="list" parameterType="int" resultType="PhotostoryCommentListDto">
 		select * from photostory_comment_list where photostory_no = #{photostoryNo}
+		order by photostory_comment_date desc
 	</select>
 	
 	<!-- 포토스토리 최신 댓글 리스트 조회 -->

--- a/final-project/src/main/resources/mybatis/mapper/photostory/photostoryList-mapper.xml
+++ b/final-project/src/main/resources/mybatis/mapper/photostory/photostoryList-mapper.xml
@@ -12,9 +12,10 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 			select rownum rn, tmp.* from (
 				select * from photostory_list
 				<where>
-					<if test="searchType != null and searchKeyword != null">
+					<if test="searchKeyword != null">
 						<![CDATA[
-							instr(${searchType}, #{searchKeyword}) > 0
+							instr(member_nick, #{searchKeyword}) > 0 or
+							instr(photostory_content, #{searchKeyword}) > 0
 						]]>
 					</if>
 				</where>

--- a/final-project/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/final-project/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -70,24 +70,24 @@
 		<interceptor>
 			<mapping path="/photostory/**"/>
 			<mapping path="/process/**"/>
+			<mapping path="/report/**"/>
 			<mapping path="/member/logout"/>
 			<mapping path="/member/editProfile"/>
 			<mapping path="/member/exit"/>
+			<mapping path="/member/profile/edit**"/>
 			<exclude-mapping path="/photostory"/>
 			<exclude-mapping path="/photostory/detail"/>
 			<beans:bean class="com.kh.finale.interceptor.MemberLoginInterceptor"></beans:bean>
 		</interceptor>
 		
 		<!-- 회원의 비회원 기능 접근 차단 인터셉터 -->
-<!-- 		<interceptor> -->
-<!-- 			<mapping path="/member/**"/> -->
-<!-- 			<exclude-mapping path="/member/idCheck"/> -->
-<!-- 			<exclude-mapping path="/member/nickCheck"/> -->
-<!-- 			<exclude-mapping path="/member/logout"/> -->
-<!-- 			<exclude-mapping path="/member/editProfile"/> -->
-<!-- 			<exclude-mapping path="/member/exit"/> -->
-<!-- 			<beans:bean class="com.kh.finale.interceptor.MemberLogoutInterceptor"></beans:bean> -->
-<!-- 		</interceptor> -->
+		<interceptor>
+			<mapping path="/member/**"/>
+			<exclude-mapping path="/member/profile/**"/>
+			<exclude-mapping path="/member/logout"/>
+			<exclude-mapping path="/member/exit"/>
+			<beans:bean class="com.kh.finale.interceptor.MemberLogoutInterceptor"></beans:bean>
+		</interceptor>
 		
 		<!-- 정지된 회원의 기능 사용 제한 인터셉터 -->
 		<interceptor>
@@ -106,10 +106,10 @@
 		</interceptor>
 
 		<!-- 관리자 기능 접근 차단 인터셉터 -->
-		<interceptor>
-			<mapping path="/admin/**"/>
-			<beans:bean class="com.kh.finale.interceptor.AdminInterceptor"></beans:bean>
-		</interceptor>
+<!-- 		<interceptor> -->
+<!-- 			<mapping path="/admin/**"/> -->
+<!-- 			<beans:bean class="com.kh.finale.interceptor.AdminInterceptor"></beans:bean> -->
+<!-- 		</interceptor> -->
 		
 	</interceptors>
 </beans:beans>

--- a/final-project/src/main/webapp/WEB-INF/views/home.jsp
+++ b/final-project/src/main/webapp/WEB-INF/views/home.jsp
@@ -114,7 +114,7 @@
 							<c:choose>
 							<c:when test="${isLogin}">
 								<li><a class="text-white text-nowrap" href="${root}/member/logout">로그아웃</a></li>
-								<li><a class="text-white text-nowrap" href="${root}/member/${memberDto.memberNick}">마이페이지</a></li>
+								<li><a class="text-white text-nowrap" href="${root}/member/profile/${memberDto.memberNick}">마이페이지</a></li>
 							</c:when>
 							<c:otherwise>
 								<li><a class="text-white text-nowrap" href="${root}/member/login">로그인</a></li>

--- a/final-project/src/main/webapp/WEB-INF/views/member/myPage.jsp
+++ b/final-project/src/main/webapp/WEB-INF/views/member/myPage.jsp
@@ -133,18 +133,18 @@ $(function(){
 		<div class="row">
 			<div class="col-lg-3 offset-lg-1">
 				<label for="memberProfile"> 
-					<img class='upload_img my-3 user_profile_lg user_profile' src="profileImage?memberId=${memberDto.memberId}"
+					<img class='upload_img my-3 user_profile_lg user_profile' src="profileImage?memberId=${profileMemberDto.memberId}"
 					onerror="this.src='${pageContext.request.contextPath}/image/default_user_profile.jpg'"> 
 					<input class="input_img" type="file" accept=".png, .jpg, .gif" id="memberProfile" name="memberProfile" style="display: none" disabled/>
 				</label>
 			</div>
 			<div class="col-lg-7">
 				<div class="row my-3 align-items-center">
-					<div class="col-4" style="font-size: 2rem">${memberDto.memberNick}</div>
+					<div class="col-4" style="font-size: 2rem">${profileMemberDto.memberNick}</div>
 					
 					<div class="col-4">
 					<c:choose>
-						<c:when test="${memberDto.memberNo==memberNo}">
+						<c:when test="${profileMemberDto.memberNo==memberNo}">
 							<a class="btn btn-outline-secondary" href="editProfile" role="button">프로필 편집</a>
 						</c:when>
 						<c:otherwise>
@@ -173,16 +173,16 @@ $(function(){
 					
 					<div class="col-4">
 					<c:choose>
-						<c:when test="${memberDto.memberNo==memberNo}">
+						<c:when test="${profileMemberDto.memberNo==memberNo}">
 							<div class="dropdown">
 								<a href="#" role="button" id="dropdownMenuLink"
 									data-toggle="dropdown"><i class="fas fa-cog fa-2x"></i></a>
 	
 								<div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-									<a class="dropdown-item" href="findPw">비밀번호 변경</a>
+									<a class="dropdown-item" href="${pageContext.request.contextPath}/member/findPw">비밀번호 변경</a>
 									<a class="dropdown-item" href="#">문제 신고</a> 
-									<a class="dropdown-item" href="logout">로그아웃</a> 
-									<a class="dropdown-item text-danger confirm-link" data-message="정말 탈퇴하시겠습니까?" href="exit">회원 탈퇴</a> 
+									<a class="dropdown-item" href="${pageContext.request.contextPath}/member/logout">로그아웃</a> 
+									<a class="dropdown-item text-danger confirm-link" data-message="정말 탈퇴하시겠습니까?" href="${pageContext.request.contextPath}/member/exit">회원 탈퇴</a> 
 								</div>
 							</div>
 						</c:when>
@@ -202,7 +202,7 @@ $(function(){
 					</div>
 				</div>
 				<div class="row">
-					<div class="col-12">${memberDto.memberIntro}</div>
+					<div class="col-12">${profileMemberDto.memberIntro}</div>
 				</div>
 
 			</div>

--- a/final-project/src/main/webapp/WEB-INF/views/template/header.jsp
+++ b/final-project/src/main/webapp/WEB-INF/views/template/header.jsp
@@ -278,7 +278,7 @@
 						<c:choose>
 							<c:when test="${isLogin}">
 									<li><a class="text-nowrap" href="${root}/member/logout">로그아웃</a></li>
-									<li><a class="text-nowrap" href="${root}/member/${memberDto.memberNick}">마이페이지</a></li>
+									<li><a class="text-nowrap" href="${root}/member/profile/${memberDto.memberNick}">마이페이지</a></li>
 							</c:when>
 							<c:otherwise>
 							<li><a class="text-nowrap"  href="${root}/member/login">로그인</a></li>

--- a/final-project/src/test/java/com/kh/finale/block/MemberBlockTest.java
+++ b/final-project/src/test/java/com/kh/finale/block/MemberBlockTest.java
@@ -1,5 +1,9 @@
 package com.kh.finale.block;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,7 +12,11 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import com.kh.finale.entity.block.MemberBlockDto;
+import com.kh.finale.repository.block.MemberBlockDao;
 import com.kh.finale.service.block.MemberBlockService;
+import com.kh.finale.util.DateUtils;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 회원 정지 관련 테스트
@@ -20,14 +28,18 @@ import com.kh.finale.service.block.MemberBlockService;
 	"file:src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml"
 })
 @WebAppConfiguration
+@Slf4j
 public class MemberBlockTest {
 
+	@Autowired
+	private MemberBlockDao memberBlockDao;
+	
 	@Autowired
 	private MemberBlockService memberBlockService;
 	
 	// 정지 테스트
 	@Test
-	public void block() {
+	public void block() throws ParseException {
 		MemberBlockDto memberBlockDto = MemberBlockDto.builder()
 				.memberNo(119)
 				.blockPeriod(1)
@@ -35,6 +47,14 @@ public class MemberBlockTest {
 				.blockReason("차단 이유")
 				.build();
 		memberBlockService.block(memberBlockDto);
+		log.debug("blockStartDate = {}", memberBlockDto.getBlockStartDate());
+		memberBlockDto = memberBlockDao.getBlockInfo(memberBlockDto.getMemberNo());
+		log.debug("blockStartDate = {}", memberBlockDto.getBlockStartDate());
+		
+		// 정지 해제 날짜 설정
+		java.sql.Date blockEndDate = DateUtils.formatToSqlDate(DateUtils.plusDayToDate(memberBlockDto.getBlockStartDate(), memberBlockDto.getBlockPeriod()));
+		memberBlockDto.setBlockEndDate(blockEndDate);
+		log.debug("blockEndDate = {}", memberBlockDto.getBlockEndDate());
 	}
 	
 	// 정지 해제 테스트

--- a/final-project/src/test/java/com/kh/finale/photostory/GetPhotostoryCountTest.java
+++ b/final-project/src/test/java/com/kh/finale/photostory/GetPhotostoryCountTest.java
@@ -35,7 +35,6 @@ public class GetPhotostoryCountTest {
 				.endRow(10)
 				.pageNo(1)
 				.pageSize(10)
-				.searchType(null)
 				.searchKeyword(null)
 				.startBlock(1)
 				.endBlock(1)

--- a/final-project/src/test/java/com/kh/finale/photostory/PhotostoryListTest.java
+++ b/final-project/src/test/java/com/kh/finale/photostory/PhotostoryListTest.java
@@ -44,7 +44,6 @@ public class PhotostoryListTest {
 				.endRow(10)
 				.pageNo(1)
 				.pageSize(10)
-				.searchType(null)
 				.searchKeyword(null)
 				.startBlock(1)
 				.endBlock(1)


### PR DESCRIPTION
- 마이페이지 주소를 '/member/닉네임'에서 '/member/profile/닉네임'으로 변경
- 마이페이지 주소 변경에 따른 다른 마이페이지 관련 기능들 주소 변경
- 구조 개선에 따른 마이페이지 버튼의 링크 수정
- 회원 정지로 인해 차단 시 block 파라미터 전송
- 포토스토리 검색 기능 변경에 따른 searchType 제거
- 인터셉터 매핑 주소 변경
- log.debug를 이용해 콘솔에 인터셉터 차단 문구 출력
- 관리자 인터셉터 임시 주석 처리