### PR TITLE
회원 정지, 회원탈퇴, 프로필 편집 오류 수정 및 인터셉터 매핑 경로 추가

### DIFF
--- a/final-project/src/main/java/com/kh/finale/controller/member/MemberController.java
+++ b/final-project/src/main/java/com/kh/finale/controller/member/MemberController.java
@@ -226,7 +226,16 @@ public class MemberController {
 
 	// 비밀번호 찾기 (변경 페이지 이동)
 	@GetMapping("/changePw")
-	public String changePw(@ModelAttribute MemberAuthDto memberAuthDto, Model model) {
+	public String changePw(@ModelAttribute MemberAuthDto memberAuthDto, Model model, HttpSession session) {
+		// 회원 정보 전송
+		int memberNo = 0;
+		if (session.getAttribute("memberNo") != null) {
+			memberNo = (int) session.getAttribute("memberNo");
+			MemberDto memberDto = memberDao.findInfo(memberNo);
+			
+			model.addAttribute("memberDto", memberDto);
+		}
+		
 		System.out.println("인증페이지 수신값 : " + memberAuthDto);
 		MemberAuthDto selectMember = memberAuthService.selectId(memberAuthDto);
 		System.out.println("db 수신 값 : " + selectMember);
@@ -329,8 +338,8 @@ public class MemberController {
 	@GetMapping("/exit")
 	public String exit(HttpSession httpSession, MemberVo memberVo) {
 		memberVo.setMemberId((String) httpSession.getAttribute("memberId"));
-		memberEditService.exit(memberVo);
 		memberEditService.exitProfile(memberVo);
+		memberEditService.exit(memberVo);
 		httpSession.removeAttribute("memberNo");
 		httpSession.removeAttribute("memberId");
 		return "member/exit";

--- a/final-project/src/main/java/com/kh/finale/controller/photostory/PhotostoryViewController.java
+++ b/final-project/src/main/java/com/kh/finale/controller/photostory/PhotostoryViewController.java
@@ -168,7 +168,9 @@ public class PhotostoryViewController {
 	public String write(@ModelAttribute PhotostoryVO photostoryVO,
 			HttpSession session) throws IllegalStateException, IOException {
 		int memberNo = (int) session.getAttribute("memberNo");
+		int plannerNo = 2; // 임시
 		photostoryVO.setMemberNo(memberNo);
+		photostoryVO.setPlannerNo(plannerNo); // 임시
 		
 		photostoryService.insertPhotostory(photostoryVO);
 		
@@ -200,7 +202,8 @@ public class PhotostoryViewController {
 			HttpSession session) throws IllegalStateException, IOException {
 		int memberNo = (int) session.getAttribute("memberNo");
 		photostoryVO.setMemberNo(memberNo);
-		
+		int plannerNo = 2; // 임시
+		photostoryVO.setPlannerNo(plannerNo); // 임시
 		photostoryService.updatePhotostory(photostoryVO);
 		
 		return "redirect:/photostory/detail?photostoryNo=" + photostoryVO.getPhotostoryNo();

--- a/final-project/src/main/java/com/kh/finale/entity/block/MemberBlockDto.java
+++ b/final-project/src/main/java/com/kh/finale/entity/block/MemberBlockDto.java
@@ -17,9 +17,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class MemberBlockDto {
 	private int blockNo, memberNo;
-	private Date blockStartDate;
+	private Date blockStartDate, blockEndDate;
 	private int blockPeriod;
 	private String blockContent, blockReason;
-	
-	private Date blockEndDate;
 }

--- a/final-project/src/main/java/com/kh/finale/repository/block/MemberBlockDao.java
+++ b/final-project/src/main/java/com/kh/finale/repository/block/MemberBlockDao.java
@@ -1,10 +1,12 @@
 package com.kh.finale.repository.block;
 
+import java.text.ParseException;
+
 import com.kh.finale.entity.block.MemberBlockDto;
 
 public interface MemberBlockDao {
 	// 회원 정지 정보 등록 기능
-	void insertBlockInfo(MemberBlockDto memberBlockDto);
+	void insertBlockInfo(MemberBlockDto memberBlockDto) throws ParseException;
 
 	// 회원 정지 정보 삭제 기능
 	void deleteBlockInfo(int memberNo);

--- a/final-project/src/main/java/com/kh/finale/repository/block/MemberBlockDaoImpl.java
+++ b/final-project/src/main/java/com/kh/finale/repository/block/MemberBlockDaoImpl.java
@@ -1,5 +1,7 @@
 package com.kh.finale.repository.block;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.apache.ibatis.session.SqlSession;
@@ -17,7 +19,18 @@ public class MemberBlockDaoImpl implements MemberBlockDao {
 	
 	// 회원 정지 정보 등록 기능
 	@Override
-	public void insertBlockInfo(MemberBlockDto memberBlockDto) {
+	public void insertBlockInfo(MemberBlockDto memberBlockDto) throws ParseException {
+		SimpleDateFormat simpleDateformat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");				
+		String currentTime = simpleDateformat.format(System.currentTimeMillis());
+		java.sql.Date sysdate = DateUtils.formatToSqlDate(simpleDateformat.parse(currentTime));
+		
+		// 정지 해제 날짜 계산 및 설정
+		java.sql.Date blockEndDate = DateUtils.formatToSqlDate(
+				DateUtils.plusDayToDate(sysdate, memberBlockDto.getBlockPeriod())
+		);
+		memberBlockDto.setBlockStartDate(sysdate);
+		memberBlockDto.setBlockEndDate(blockEndDate);
+		
 		sqlSession.insert("memberBlock.insert", memberBlockDto);
 	}
 
@@ -42,7 +55,6 @@ public class MemberBlockDaoImpl implements MemberBlockDao {
 		
 		// 정지 해제 날짜 계산
 		Date blockEndDate = memberBlockDto.getBlockEndDate();
-		
 		return DateUtils.compareWithSysdate(blockEndDate);
 	}
 }

--- a/final-project/src/main/java/com/kh/finale/repository/member/MemberProfileDaoImpl.java
+++ b/final-project/src/main/java/com/kh/finale/repository/member/MemberProfileDaoImpl.java
@@ -8,7 +8,7 @@ import com.kh.finale.entity.member.MemberProfileDto;
 import com.kh.finale.vo.member.MemberVo;
 
 @Repository
-public class MemberProfileImpl implements MemberProfileDao{
+public class MemberProfileDaoImpl implements MemberProfileDao{
 	
 	@Autowired
 	private SqlSession sqlSession;

--- a/final-project/src/main/java/com/kh/finale/restcontroller/block/MemberBlockRestController.java
+++ b/final-project/src/main/java/com/kh/finale/restcontroller/block/MemberBlockRestController.java
@@ -1,6 +1,7 @@
 package com.kh.finale.restcontroller.block;
 
 import java.sql.Date;
+import java.text.ParseException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -26,15 +27,8 @@ public class MemberBlockRestController {
 	
 	// 회원 정지 처리
 	@PostMapping("/block")
-	public void block(@ModelAttribute MemberBlockDto memberBlockDto) {
+	public void block(@ModelAttribute MemberBlockDto memberBlockDto) throws ParseException {
 		memberBlockService.block(memberBlockDto);
-		
-		// 정지 해제 날짜 계산 및 설정
-		memberBlockDto = memberBlockDao.getBlockInfo(memberBlockDto.getMemberNo());
-		Date blockEndDate = DateUtils.formatToSqlDate(
-				DateUtils.plusDayToDate(memberBlockDto.getBlockStartDate(), memberBlockDto.getBlockPeriod())
-		);
-		memberBlockDto.setBlockEndDate(blockEndDate);
 	}
 	
 	// 회원 정지 해제 처리

--- a/final-project/src/main/java/com/kh/finale/service/block/MemberBlockService.java
+++ b/final-project/src/main/java/com/kh/finale/service/block/MemberBlockService.java
@@ -1,10 +1,12 @@
 package com.kh.finale.service.block;
 
+import java.text.ParseException;
+
 import com.kh.finale.entity.block.MemberBlockDto;
 
 public interface MemberBlockService {
 	// 회원 정지
-	public void block(MemberBlockDto memberBlockDto);
+	public void block(MemberBlockDto memberBlockDto) throws ParseException;
 	
 	// 회원 정지 해제
 	public void unblock(int memberNo);

--- a/final-project/src/main/java/com/kh/finale/service/block/MemberBlockServiceImpl.java
+++ b/final-project/src/main/java/com/kh/finale/service/block/MemberBlockServiceImpl.java
@@ -1,5 +1,7 @@
 package com.kh.finale.service.block;
 
+import java.text.ParseException;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +22,7 @@ public class MemberBlockServiceImpl implements MemberBlockService {
 	// 회원 정지
 	@Override
 	@Transactional
-	public void block(MemberBlockDto memberBlockDto) {
+	public void block(MemberBlockDto memberBlockDto) throws ParseException {
 		memberDao.block(memberBlockDto.getMemberNo());
 		memberBlockDao.insertBlockInfo(memberBlockDto);
 	}

--- a/final-project/src/main/java/com/kh/finale/service/member/MemberEditServiceImpl.java
+++ b/final-project/src/main/java/com/kh/finale/service/member/MemberEditServiceImpl.java
@@ -42,7 +42,17 @@ public class MemberEditServiceImpl implements MemberEditService{
 													.profileSize(memberVo.getMemberProfile().getSize())
 													.profileSaveName(FileName)
 													.build();
-		memberProfileDao.update(memberProfileDto);
+		
+		// 기존 프로필 이미지의 존재 유무 확인
+		MemberProfileDto find = memberProfileDao.find(memberVo.getMemberId());
+		
+		// 기존 프로필 이미지가 존재하면 업데이트, 아니면 등록
+		if (find != null) {
+			memberProfileDao.update(memberProfileDto);
+		} else {
+			memberProfileDao.insert(memberProfileDto);
+		}
+		
 		System.out.println("수정 DB 값 확인" + memberProfileDto);
 		}
 		

--- a/final-project/src/main/java/com/kh/finale/service/photostory/PhotostoryServiceImpl.java
+++ b/final-project/src/main/java/com/kh/finale/service/photostory/PhotostoryServiceImpl.java
@@ -83,9 +83,7 @@ public class PhotostoryServiceImpl implements PhotostoryService {
 		// 경로 설정 및 생성
 		File dir = new File("D:/upload/kh5/photostory/");
 		dir.mkdirs();
-		for (int i = 0; i < photostoryVO.getPhotostoryPhoto().length; i++) {
-			System.out.println("사진: " + photostoryVO.getPhotostoryPhoto()[i]);
-		}
+
 		for (int i = 0; i < photostoryVO.getPhotostoryPhoto().length; i++) {
 			if (ArrayUtils.contains(photostoryVO.getIndex(), i)) {
 				String filePath = String.valueOf(photostoryVO.getPhotostoryNo()) + "/"

--- a/final-project/src/main/resources/mybatis/mapper/block/memberBlock-mapper.xml
+++ b/final-project/src/main/resources/mybatis/mapper/block/memberBlock-mapper.xml
@@ -8,8 +8,8 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 
 	<!-- 회원 정지 정보 등록 -->
 	<insert id="insert" parameterType="MemberBlockDto">
-		insert into member_block(block_no, member_no, block_period, block_content, block_reason)
-		values(member_block_seq.nextval, #{memberNo}, #{blockPeriod}, #{blockContent}, #{blockReason})
+		insert into member_block(block_no, member_no, block_start_date, block_end_date, block_period, block_content, block_reason)
+		values(member_block_seq.nextval, #{memberNo}, #{blockStartDate}, #{blockEndDate}, #{blockPeriod}, #{blockContent}, #{blockReason})
 	</insert>
 	
 	<!-- 회원 정지 정보 삭제 -->

--- a/final-project/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/final-project/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -84,8 +84,12 @@
 		<interceptor>
 			<mapping path="/member/**"/>
 			<exclude-mapping path="/member/profile/**"/>
+			<exclude-mapping path="/member/findPw"/>
+			<exclude-mapping path="/member/changePw"/>
+			<exclude-mapping path="/member/edit"/>
 			<exclude-mapping path="/member/logout"/>
 			<exclude-mapping path="/member/exit"/>
+			<exclude-mapping path="/member/*Email"/>
 			<beans:bean class="com.kh.finale.interceptor.MemberLogoutInterceptor"></beans:bean>
 		</interceptor>
 		
@@ -95,6 +99,7 @@
 			<mapping path="/process/**"/>
 			<exclude-mapping path="/photostory"/>
 			<exclude-mapping path="/photostory/detail"/>
+			<exclude-mapping path="/photostory/photo/**"/>
 			<beans:bean class="com.kh.finale.interceptor.MemberBlockInterceptor"></beans:bean>
 		</interceptor>
 		

--- a/final-project/src/test/java/com/kh/finale/block/MemberBlockTest.java
+++ b/final-project/src/test/java/com/kh/finale/block/MemberBlockTest.java
@@ -41,7 +41,7 @@ public class MemberBlockTest {
 	@Test
 	public void block() throws ParseException {
 		MemberBlockDto memberBlockDto = MemberBlockDto.builder()
-				.memberNo(119)
+				.memberNo(4)
 				.blockPeriod(1)
 				.blockContent("차단글 내용")
 				.blockReason("차단 이유")
@@ -50,17 +50,13 @@ public class MemberBlockTest {
 		log.debug("blockStartDate = {}", memberBlockDto.getBlockStartDate());
 		memberBlockDto = memberBlockDao.getBlockInfo(memberBlockDto.getMemberNo());
 		log.debug("blockStartDate = {}", memberBlockDto.getBlockStartDate());
-		
-		// 정지 해제 날짜 설정
-		java.sql.Date blockEndDate = DateUtils.formatToSqlDate(DateUtils.plusDayToDate(memberBlockDto.getBlockStartDate(), memberBlockDto.getBlockPeriod()));
-		memberBlockDto.setBlockEndDate(blockEndDate);
 		log.debug("blockEndDate = {}", memberBlockDto.getBlockEndDate());
 	}
 	
 	// 정지 해제 테스트
 //	@Test
 //	public void unblock() {
-//		int memberNo = 119;
+//		int memberNo = 4;
 //		memberBlockService.unblock(memberNo);
 //	}
 }


### PR DESCRIPTION
- 비밀번호 변경 페이지에서 잘못된 링크로 연결된 마이페이지 수정
- 회원탈퇴 시 프로필 사진 정보부터 삭제되게 순서 변경
- 포토스토리 작성, 수정 시 플래너 번호를 임시로 2로 고정
- 정지 해제 날짜가 제대로 설정되지 않는 문제 수정
- 프로필 편집 시 기존 프로필 이미지가 없을 경우 프로필 이미지가 등록되지 않는 문제 수정
- 인터셉터 매핑 경로 추가